### PR TITLE
Fixed Document Statistics -> Compute Sentence Length Bug

### DIFF
--- a/src/statistics_txt_main.py
+++ b/src/statistics_txt_main.py
@@ -41,6 +41,7 @@ def run(inputFilename, inputDir, outputDir,
         return
 
     # corpus statistics --------------------------------------------------------------------
+    import statistics_txt_util
 
     if corpus_statistics_var:
         stopwords_var = False
@@ -54,7 +55,7 @@ def run(inputFilename, inputDir, outputDir,
             stopwords_var = True
         if "*" in corpus_statistics_options_menu_var or 'frequencies' in corpus_statistics_options_menu_var:
 
-            import statistics_txt_util
+
             outputFiles, outputDir = statistics_txt_util.compute_corpus_statistics(window, inputFilename, inputDir, outputDir,
                                                                         config_filename, False, 
                                                                         chartPackage, dataTransformation,stopwords_var, lemmatize_var)


### PR DESCRIPTION
<img width="1462" alt="image" src="https://github.com/NLP-Suite/NLP-Suite/assets/47804337/2f10abf2-878b-4c13-830c-07c9b6e7f47d">

Previously when you tried to only compute the sentence lengths in `Corpus/document(s) statistics (Sentences, words, lines)`, an import bug occurred. 

<img width="1536" alt="image" src="https://github.com/NLP-Suite/NLP-Suite/assets/47804337/a80db6fb-a3ea-4f91-b40e-09c54a88ed58">

However moving the import statement for `statistics_txt_util ` above the if-statements fixed it (`Line 44`)
