### PR TITLE
Add Dockerized CoreNLP and MALLET services

### DIFF
--- a/corenlp/Dockerfile
+++ b/corenlp/Dockerfile
@@ -1,0 +1,40 @@
+FROM alpine:3.19 as builder
+MAINTAINER Arne Neumann <nlpbox.programming@arne.cl>
+
+RUN apk update && apk add py3-pip wget
+
+WORKDIR /opt
+
+# install grepurl script to retrieve the most current download URL of CoreNLP.
+# install latest CoreNLP release.
+RUN pip install grepurl --break-system-packages && \
+  wget `grepurl -r 'stanford-corenlp-.*\.zip' -a http://stanfordnlp.github.io/CoreNLP` && \
+  unzip stanford-corenlp-*.zip && \
+  mv $(ls -d stanford-corenlp-*/) corenlp && rm *.zip
+
+# install latest English language model
+#
+# Docker can't store the result of a RUN command in an ENV, so we'll have
+# to use this workaround.
+# This command get's the first model file (at least for English there are two)
+# and extracts its property file.
+WORKDIR /opt/corenlp
+RUN wget $(grepurl -r 'english.*jar$' -a http://stanfordnlp.github.io/CoreNLP | head -n 1)
+
+
+# only keep the things we need to run and test CoreNLP
+FROM alpine:3.19
+
+RUN apk update && apk add openjdk8-jre-base py3-pip curl && \
+  pip install pytest pexpect requests --break-system-packages
+
+WORKDIR /opt/corenlp
+COPY --from=builder /opt/corenlp .
+
+ENV JAVA_XMX 4g
+ENV TIMEOUT_MILLISECONDS 999999
+ENV PORT 9000
+
+EXPOSE $PORT
+
+CMD java -mx$JAVA_XMX -cp "*" edu.stanford.nlp.pipeline.StanfordCoreNLPServer -port $PORT -timeout $TIMEOUT_MILLISECONDS

--- a/corenlp/README.md
+++ b/corenlp/README.md
@@ -1,0 +1,36 @@
+# Dockerized Stanford CoreNLP
+
+This directory builds a Docker image that runs the [Stanford CoreNLP server](https://stanfordnlp.github.io/CoreNLP/corenlp-server.html). It removes the need to install Java + CoreNLP locally — one of the most common install pain points reported by NLP-Suite users.
+
+The Dockerfile is adapted from [NLPbox/stanford-corenlp-docker](https://github.com/NLPbox/stanford-corenlp-docker) (MIT-licensed). It downloads the latest CoreNLP release and the English language model at build time.
+
+## Run it
+
+From the repository root:
+
+```bash
+docker compose -f docker-compose.corenlp-mallet.yml up -d corenlp
+```
+
+CoreNLP will be available at `http://localhost:9000`.
+
+## Test it
+
+```bash
+curl -s --data "Stanford CoreNLP is running." \
+  'http://localhost:9000/?properties={"annotators":"tokenize,ssplit,pos","outputFormat":"json"}'
+```
+
+You should see a JSON response with tokens, sentences, and POS tags.
+
+## Memory
+
+By default CoreNLP gets 4 GB of RAM. Override with:
+
+```bash
+JAVA_XMX=2g docker compose -f docker-compose.corenlp-mallet.yml up -d corenlp
+```
+
+## Why this is useful
+
+Today, NLP-Suite tools that depend on CoreNLP (parser, NER, SVO, coreference, etc.) require the user to download and extract the Stanford CoreNLP archive, install a matching Java runtime, and configure paths. This container packages all of that. The container is consumed by the web UI (see [PR #2](../README.md)), and future work can let the existing tkinter tools query it instead of spawning their own Java process.

--- a/docker-compose.corenlp-mallet.yml
+++ b/docker-compose.corenlp-mallet.yml
@@ -1,0 +1,22 @@
+services:
+  corenlp:
+    build: ./corenlp
+    image: nlpsuite/corenlp:local
+    ports:
+      - "9000:9000"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+
+  mallet:
+    build: ./mallet
+    image: nlpsuite/mallet:local
+    ports:
+      - "8081:5050"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:5050/openapi.json"]
+      interval: 10s
+      timeout: 5s
+      retries: 6

--- a/mallet/Dockerfile
+++ b/mallet/Dockerfile
@@ -1,0 +1,32 @@
+# Use amazon corretto as base image, it's an open-jdk.
+FROM amazoncorretto:17
+
+# Install unzip, curl, and Python
+RUN yum install -y unzip curl python3 
+
+#Install fastapi and uvicorn.
+RUN pip3 install fastapi uvicorn
+
+# Install MALLET
+RUN curl -LO http://mallet.cs.umass.edu/dist/mallet-2.0.8.zip && \
+    unzip mallet-2.0.8.zip && \
+    mv mallet-2.0.8 /opt/mallet
+
+# Set MALLET environment variables
+ENV MALLET_HOME=/opt/mallet
+ENV PATH="${MALLET_HOME}/bin:${PATH}"
+ENV CLASSPATH="${MALLET_HOME}/class"
+
+# Link mallet script (optional now, but can keep, makes it easier to run commands)
+RUN ln -s /opt/mallet/bin/mallet /usr/local/bin/mallet
+
+# Add the FastAPI app and input file (safe location -> optional folder?)
+COPY api.py /opt/mallet_api/api.py
+
+WORKDIR /opt/mallet_api
+
+EXPOSE 5050
+
+#RUN FastAPI with uvicorn 
+CMD ["uvicorn", "api:app", "--host", "0.0.0.0", "--port", "5050"]
+

--- a/mallet/README.md
+++ b/mallet/README.md
@@ -1,0 +1,46 @@
+# Dockerized MALLET
+
+This directory builds a Docker image that wraps [MALLET](https://mimno.github.io/Mallet/) (the Java-based topic-modeling toolkit) behind a small HTTP API. It removes the need to install Java + MALLET locally.
+
+The container is built on Amazon Corretto 17 and installs MALLET 2.0.8. A thin FastAPI app (`api.py`) exposes a single endpoint that runs `mallet <command>` with the given arguments.
+
+## Run it
+
+From the repository root:
+
+```bash
+docker compose -f docker-compose.corenlp-mallet.yml up -d mallet
+```
+
+The API will be available at `http://localhost:8081`.
+
+## API
+
+`POST /run` accepts JSON of the form:
+
+```json
+{
+  "command": "import-dir",
+  "args": {
+    "input": "/app/my-corpus",
+    "output": "/app/out.mallet",
+    "keep-sequence": true
+  }
+}
+```
+
+This runs `mallet import-dir --input /app/my-corpus --output /app/out.mallet --keep-sequence`. Boolean `true` becomes a flag; other values become `--key value` pairs.
+
+The container expects the corpus to live inside `/app` (mount your data with `-v $PWD:/app` if running standalone). The full Docker-compose setup in [PR #2](../README.md) wires this volume mount automatically.
+
+## Test it
+
+```bash
+curl -s http://localhost:8081/openapi.json | head -c 200
+```
+
+You should see the FastAPI schema document.
+
+## Why this is useful
+
+Topic-modeling tools in NLP-Suite require a working MALLET install, which is a frequent source of setup failures. This container packages MALLET and a uniform HTTP interface. The container is consumed by the web UI (see [PR #2](../README.md)).

--- a/mallet/api.py
+++ b/mallet/api.py
@@ -1,0 +1,30 @@
+import subprocess
+
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+
+app = FastAPI()
+
+
+@app.post("/run")
+async def run_mallet(request: Request):
+    data = await request.json()
+    command = data.get("command")
+    args = data.get("args", {})
+
+    if not command:
+        return JSONResponse(content={"error": "No command specified"}, status_code=400)
+
+    cmd = ["mallet", command]
+
+    for key, value in args.items():
+        if isinstance(value, bool) and value is not None:
+            cmd.append(f"--{key}")
+        elif value is not None:
+            cmd.extend([f"--{key}", str(value)])
+
+    try:
+        subprocess.run(cmd, check=True)
+        return JSONResponse(content={"status": "success", "cmd": cmd})
+    except subprocess.CalledProcessError as e:
+        return JSONResponse(content={"status": "error", "cmd": cmd, "details": str(e)}, status_code=500)


### PR DESCRIPTION
## What this adds

Two small Docker services that package the Java tools NLP-Suite already depends on:

- **CoreNLP** — Stanford CoreNLP server, available at `http://localhost:9000` once running
- **MALLET** — MALLET 2.0.8 behind a thin HTTP wrapper, available at `http://localhost:8081`

Plus a `docker-compose.corenlp-mallet.yml` at the repo root so both services come up with one command:

```bash
docker compose -f docker-compose.corenlp-mallet.yml up -d
```

That's it for this PR.

## Why this is useful

A large share of the support requests on this project come from users who can't get **Java + Stanford CoreNLP** or **Java + MALLET** installed correctly. The Docker images here download and configure those tools at build time, so a user only needs Docker installed.

The containers don't change any existing behavior. They're a building block: PR #2 (coming) wires a web UI on top of them, and they could also be consumed by the existing tkinter tools as a future step.

## What this does *not* change

- No file in `src/` is modified
- The tkinter entrypoint (`src/NLP_menu_main.py`) is untouched
- The PyInstaller build (`NLP_Suite.spec`, `post_build_fixup.py`, `.github/workflows/`) is unaffected
- `setup_Mac/` and `setup_Windows/` are not modified — existing install paths continue to work exactly as before

## How to try it

```bash
git fetch upstream pull/<PR#>/head:try-docker
git checkout try-docker
docker compose -f docker-compose.corenlp-mallet.yml up -d
# Test CoreNLP:
curl -s --data "Hello world." \
  'http://localhost:9000/?properties={"annotators":"tokenize,pos","outputFormat":"json"}'
# Test MALLET wrapper:
curl -s http://localhost:8081/openapi.json | head -c 200
```

## Files added

```
corenlp/
  Dockerfile        # Stanford CoreNLP server (port 9000)
  README.md
mallet/
  Dockerfile        # MALLET 2.0.8 + Python wrapper (port 5050 → published 8081)
  api.py            # POST /run → mallet <command> --args...
  README.md
docker-compose.corenlp-mallet.yml
```

## Attribution

The CoreNLP Dockerfile is adapted from [NLPbox/stanford-corenlp-docker](https://github.com/NLPbox/stanford-corenlp-docker) (MIT). MALLET is from [mimno/Mallet](https://mimno.github.io/Mallet/).

## Follow-up PRs

- **PR #2 (next):** Web UI + FastAPI agent that talks to these services
- **PR #3 (after):** Test suite for the agent endpoints

Marked as draft until I can confirm a clean `docker compose up` on a fresh clone end-to-end and attach a before/after screenshot of the CoreNLP install error vs. clean Docker boot.