### PR TITLE
Fix Mac welcome-screen crash (invalid command name "PyImagingPhoto") via native Tk image loading

### DIFF
--- a/src/GUI_util.py
+++ b/src/GUI_util.py
@@ -189,6 +189,23 @@ def trace_checkbox_NoLabel(checkbox_var, checkbox_text, onText, offText):
 # font Gotham for NLP
 # RGB red is #b10a0a
 
+def tk_image_from_pil(pil_image):
+    """Build a tkinter.PhotoImage from a PIL image WITHOUT PIL.ImageTk / the _imagingtk
+    C bridge. The bundled portable Python (python-build-standalone) statically embeds
+    Tcl/Tk, so _imagingtk cannot attach to it and ImageTk.PhotoImage crashes with
+        invalid command name "PyImagingPhoto"
+    Tk 8.6 decodes PNG natively, so we hand Tk base64-encoded PNG bytes through the
+    built-in PhotoImage(data=...). PIL is used only to decode/resize, which never touches
+    _imagingtk. Keep a reference to the returned image (Tk does not)."""
+    import io
+    import base64
+    if pil_image.mode not in ("RGB", "RGBA", "L", "LA", "P"):
+        pil_image = pil_image.convert("RGBA")
+    buffer = io.BytesIO()
+    pil_image.save(buffer, format="PNG")
+    return tk.PhotoImage(data=base64.b64encode(buffer.getvalue()))
+
+
 def display_logo():
     # Necessary to avoid creating a circular dependent import
     from IO_libraries_util import install_all_Python_packages
@@ -196,12 +213,12 @@ def display_logo():
         return  # PIL not installed; skip logo rather than exiting the whole app
 
     try:
-        from PIL import Image, ImageTk
+        from PIL import Image
         # https://stackoverflow.com/questions/17504570/creating-simply-image-gallery-in-python-tkinter-pil
         # https://stackoverflow.com/questions/76616042/attributeerror-module-pil-image-has-no-attribute-antialias
         image_list = [GUI_IO_util.image_libPath + os.sep + "logo.png"]
         for x in image_list:
-            img = ImageTk.PhotoImage(Image.open(x).resize((85,50), Image.LANCZOS)) #Image.ANTIALIAS))
+            img = tk_image_from_pil(Image.open(x).resize((85,50), Image.LANCZOS)) #Image.ANTIALIAS))
             logo = tk.Label(window, width=85, height=50, anchor='nw', image=img)
             logo.image = img
             # the logo has some white spaces to its left; better cutting this so that it can be aligned with HELP? buttons

--- a/src/NLP_welcome_main.py
+++ b/src/NLP_welcome_main.py
@@ -16,7 +16,7 @@ from itertools import cycle
 # https://pillow.readthedocs.io/en/stable/installation.html
 # Pillow and PIL cannot co-exist in the same environment. Before installing Pillow, please uninstall PIL.
 # Pillow >= 1.0 no longer supports “import Image”. Please use “from PIL import Image” instead.
-from PIL import Image, ImageTk
+from PIL import Image
 from subprocess import call
 
 import GUI_IO_util
@@ -125,7 +125,10 @@ def make_images(canvas_width, canvas_height):
         # https://stackoverflow.com/questions/76616042/attributeerror-module-pil-image-has-no-attribute-antialias
         image_obj = Image.open(image).resize((int(image_width), int(image_height)), Image.Resampling.LANCZOS)
         images.append(image_obj)
-        photo_image = ImageTk.PhotoImage(image_obj)
+        # Native Tk PhotoImage (no PIL.ImageTk/_imagingtk) - see GUI_util.tk_image_from_pil:
+        # the bundled portable Python's statically-embedded Tcl/Tk crashes ImageTk with
+        # invalid command name "PyImagingPhoto".
+        photo_image = GUI_util.tk_image_from_pil(image_obj)
         photos_list.append(photo_image)
 
     photos1 = cycle(photos_list[0:len(image_1_list)])


### PR DESCRIPTION
## Problem
On the bundled Mac build, the welcome screen crashes while loading images with:
```
_tkinter.TclError: invalid command name "PyImagingPhoto"
```

The welcome screen runs inside the bundled `python-env` (`NLP_menu_main.py` → `run_script_util` → `python-env/bin/python3 NLP_welcome_main.py`). That portable Python (`python-build-standalone`) **statically embeds Tcl/Tk**, so PIL's `_imagingtk` C bridge can't attach to the interpreter's Tk and `ImageTk.PhotoImage` fails.

## Why not "rebuild Pillow"
Verified on Apple Silicon against the exact CI `python-env` (cpython-3.10.15 python-build-standalone): the prebuilt Pillow wheel **and** a from-source rebuild against matching Tcl/Tk 8.6.18 headers **both still crash** with `PyImagingPhoto`. The embedded static Tk is the blocker, not the Pillow build.

## Fix
Tk 8.6 decodes PNG natively, and PIL's decode/resize never touch `_imagingtk`. New helper `GUI_util.tk_image_from_pil()` resizes with PIL, then hands Tk base64 PNG bytes via the built-in `PhotoImage(data=...)`. Used for:
- the welcome logo — `GUI_util.display_logo()`
- the welcome carousel — `NLP_welcome_main.py` `make_images()`

No CI / vendored-binary / Pillow-version changes. `Pillow==10.4.0` pin unchanged.

## Testing
On Apple Silicon, against the CI python-env: reproduced the crash with the shipped wheel, then confirmed the native-Tk path renders the real `logo.png` (85×50) and `visual*.jpg` (450×250) with no crash. Both edited files compile under Python 3.10.

## Note
`GIS_Google_Earth_main.py` also uses `ImageTk` and would hit the same crash in `python-env`; left out of this PR (not reported/tested) but easy to switch to the same helper later.

## Heads-up for maintainers
`.github/workflows/build-installers.yml` checks out `ref: roberto`, so this needs to reach `roberto` for the next installer build to include it.