### PR TITLE
docs: document SRL (Semantic Role Labeling) as an optional, separate-env install

### DIFF
--- a/setup_Mac/readme_Mac_beta.md
+++ b/setup_Mac/readme_Mac_beta.md
@@ -9,7 +9,8 @@
 5. **Running the NLP Suite**
 6. **Updating the NLP Suite**
 7. **Mac Running Bash/Zsh**
-8. **Useful Conda & Pip Commands**
+8. **Semantic Role Labeling (SRL) — Optional**
+9. **Useful Conda & Pip Commands**
 
 Detailed installation instructions are available on the [NLP Suite GitHub pages](https://github.com/NLP-Suite/NLP-Suite/wiki/Install-the-NLP-Suite).
 
@@ -58,6 +59,19 @@ Detailed installation instructions are available on the [NLP Suite GitHub pages]
 - The NLP Suite updates automatically to the latest release available on GitHub every time you exit the NLP Suite. This feature relies on Git.
 - Note: if you click on the "CLOSE" button on the right lower corner, it will be successful - and is the only way. Invoking Task manager to force shut down, or directly using the "X" button on the top right might not be successful in updating.
 - Check frequently if your NLP Suite is up-to-date by visiting the current github page for release history. If you notify an incorrect release history, in addition to correcting git, the easiest solution is simply to download the entire package from GitHub all over again.  
+
+### Semantic Role Labeling (SRL) — Optional
+
+Semantic Role Labeling (the **SRL** checkbox in the SVO tool) is an **optional** feature that is **not** part of the standard installation. It runs in its own isolated Python 3.8 environment because the `transformer-srl` model pins a legacy stack (torch 1.7, allennlp, spaCy 2.x) that cannot coexist with the Suite's main packages — the same idea as Stanford CoreNLP running in its own Java runtime. (This is also why `transformer_srl` is intentionally absent from the bundled environment and should not be reported as a missing package.)
+
+To enable SRL (one time per machine; requires Anaconda/Miniconda and an internet connection):
+
+1. Open a terminal in the `NLP-Suite` folder.
+2. Run: `python setup_SRL.py`
+   - This creates a conda environment named `nlp_srl`, installs the pinned SRL dependencies, and downloads the pretrained SRL model (~400 MB).
+3. Tick the **SRL** checkbox in the SVO GUI.
+
+Until you run `setup_SRL.py`, the SVO tool simply tells you SRL is not set up; the rest of the NLP Suite is unaffected.
 
 ### Useful Anaconda & pip commands
 

--- a/setup_Windows/readme_Windows_beta.md
+++ b/setup_Windows/readme_Windows_beta.md
@@ -8,7 +8,8 @@
 4. **Installing Git**
 5. **Running the NLP Suite**
 6. **Updating the NLP Suite**
-7. **Useful conda & pip commands (prompt)**
+7. **Semantic Role Labeling (SRL) — Optional**
+8. **Useful conda & pip commands (prompt)**
    - conda commands
    - pip commands
    - prompt commands
@@ -81,6 +82,19 @@ Note: All instructions are written consequentially and in a linear way. Non of t
 - The NLP Suite updates automatically to the latest release available on GitHub every time you exit the NLP Suite. This feature relies on Git.
 - Note: if you click on the "CLOSE" button on the right lower corner, it will be successful - and is the only way. Invoking Task manager to force shut down, or directly using the "X" button on the top right might not be successful in updating.
 - Check frequently if your NLP Suite is up-to-date by visiting the current github page for release history. If you notify an incorrect release history, in addition to correcting git, the easiest solution is simply to download the entire package from GitHub all over again.  
+
+### Semantic Role Labeling (SRL) — Optional
+
+Semantic Role Labeling (the **SRL** checkbox in the SVO tool) is an **optional** feature that is **not** part of the standard installation. It runs in its own isolated Python 3.8 environment because the `transformer-srl` model pins a legacy stack (torch 1.7, allennlp, spaCy 2.x) that cannot coexist with the Suite's main packages — the same idea as Stanford CoreNLP running in its own Java runtime. (This is also why `transformer_srl` is intentionally absent from the bundled environment and should not be reported as a missing package.)
+
+To enable SRL (one time per machine; requires Anaconda/Miniconda and an internet connection):
+
+1. Open Anaconda Prompt in the `NLP-Suite` folder.
+2. Run: `python setup_SRL.py`
+   - This creates a conda environment named `nlp_srl`, installs the pinned SRL dependencies, and downloads the pretrained SRL model (~400 MB).
+3. Tick the **SRL** checkbox in the SVO GUI.
+
+Until you run `setup_SRL.py`, the SVO tool simply tells you SRL is not set up; the rest of the NLP Suite is unaffected.
 
 ### Useful Anaconda & pip commands
 


### PR DESCRIPTION
## What
Adds a short **Semantic Role Labeling (SRL) — Optional** section to both `setup_Mac/readme_Mac_beta.md` and `setup_Windows/readme_Windows_beta.md`.

## Why
SRL (the SRL checkbox in the SVO tool) runs in its **own isolated Python 3.8 conda env** because `transformer-srl` pins a legacy stack (torch 1.7 / allennlp / spaCy 2.x) that can't coexist with the Suite's main packages — see `setup_SRL.py` and `src/SRL_util.py`. It is set up once via `python setup_SRL.py` and is intentionally **not** part of the standard/bundled install.

This also clarifies that a missing `transformer_srl` in the bundled environment is **expected**, not a bug — addressing the `ModuleNotFoundError: No module named 'transformer_srl'` seen in build audits. (The companion change to stop the Mac Setup.app probe from flagging it is in a separate PR.)

## Scope
Docs only — no code or runtime behavior change. The SVO tool already gates SRL gracefully (`src/SRL_util.py` shows a 'run setup_SRL.py' message when the env/model is absent).