### PR TITLE
Add proof-of-concept unit tests for document statistics

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,20 @@
+name: tests
+
+on:
+  push:
+    branches: [current-stable]
+  pull_request:
+    branches: [current-stable]
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.9"
+      # The suite stubs the GUI/NLP stack in tests/conftest.py, so it stays
+      # hermetic: only pytest is needed, no Stanza/spaCy/NLTK install.
+      - run: pip install pytest
+      - run: pytest tests/ -v

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: "3.10"
       # The suite stubs the GUI/NLP stack in tests/conftest.py, so it stays
       # hermetic: only pytest is needed, no Stanza/spaCy/NLTK install.
       - run: pip install pytest

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+# Python
+__pycache__/
+*.py[cod]
+.pytest_cache/
+
 # OSX
 #
 .DS_Store

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,7 @@ So legacy modules are GUI/infra-coupled. Tests work around this by stubbing thes
 - Packaging: **PyInstaller** via `NLP_Suite.spec` (release builds are tag-triggered).
 
 ## Testing (PR #1635)
+- **Everything added should have associated unit tests** — new helpers, functions, or logic land together with tests that cover them (extract testable logic out of GUI callbacks so it can be tested).
 - Run with `pytest tests/`.
 - `tests/conftest.py` replaces `GUI_util`, `IO_libraries_util`, and the heavy NLP libs (Stanza/spaCy/NLTK/pandas/…) with `MagicMock` stubs in `sys.modules` **before** the module under test is imported — neutralizing the import-time guards **without changing production code**. Real stdlib (`re`, `string`, `collections`, …) is left intact.
 - **Target pure, stdlib-only helpers** (e.g. `statistics_txt_util` word/diversity helpers, `CoNLL_util`, `semantic_aggregation_util`, regex builders). Full GUI flows are not unit-testable here.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,70 @@
+"""Pytest bootstrap for the legacy NLP-Suite ``src/`` modules.
+
+The legacy modules under ``src/`` are written to be run from a Tk GUI: importing
+one (e.g. ``statistics_txt_util``) pulls in ``GUI_util`` which calls
+``tkinter.Tk()`` at module load, and ``IO_libraries_util.install_all_Python_packages``
+which shells out to ``pip``. Neither is acceptable inside a unit test (no display,
+no network, no side effects).
+
+To unit-test the pure, stdlib-only helpers without refactoring production code,
+we replace the GUI/infra modules and the heavy NLP libraries with ``MagicMock``
+stubs in ``sys.modules`` *before* the modules under test are imported. A
+``MagicMock`` makes the module's import-time guards harmless: e.g.
+``install_all_Python_packages(...) == False`` evaluates to ``False`` (a mock is
+truthy and not equal to ``False``), so the ``sys.exit(0)`` guard is skipped, and
+``import_nltk_resource(...)`` becomes a no-op.
+
+Standard-library modules the helpers actually rely on (``re``, ``string``,
+``collections``) are intentionally NOT stubbed, so the functions execute for real.
+"""
+
+import pathlib
+import sys
+from unittest.mock import MagicMock
+
+# Legacy modules import each other by bare name (``import GUI_util``), which only
+# works because ``src/`` is on sys.path at runtime. Reproduce that here.
+_SRC = pathlib.Path(__file__).resolve().parent.parent / "src"
+sys.path.insert(0, str(_SRC))
+
+# Project infra modules that drag in the Tk window / pip bootstrap.
+_INFRA_STUBS = [
+    "GUI_util",
+    "IO_libraries_util",
+    "GUI_IO_util",
+    "IO_user_interface_util",
+    "IO_files_util",
+    "IO_csv_util",
+    "charts_util",
+    "reminders_util",
+    "TIPS_util",
+    "statistics_statistical_tests_util",
+    "statistics_csv_util",
+    "run_script_util",
+    "config_util",
+    "tree",
+    "sentence_complexity_node_util",
+]
+
+# Heavy third-party libraries imported at module top but unused by the pure
+# helpers. Dotted submodules must be registered explicitly so that
+# ``from nltk.stem.porter import PorterStemmer`` resolves against the stub.
+_HEAVY_STUBS = [
+    "stanza",
+    "spacy",
+    "textstat",
+    "pandas",
+    "PIL",
+    "PIL.Image",
+    "spacytextblob",
+    "spacytextblob.spacytextblob",
+    "nltk",
+    "nltk.stem",
+    "nltk.stem.porter",
+    "nltk.corpus",
+    "nltk.tree",
+    "nltk.draw",
+]
+
+for _name in _INFRA_STUBS + _HEAVY_STUBS:
+    sys.modules.setdefault(_name, MagicMock())

--- a/tests/test_statistics_txt_util.py
+++ b/tests/test_statistics_txt_util.py
@@ -1,0 +1,34 @@
+"""Proof-of-concept unit tests for the document-statistics helpers.
+
+Targets the pure, stdlib-only functions in ``src/statistics_txt_util.py``. The
+heavy GUI/NLP import machinery is neutralised by the stubs in ``conftest.py``;
+if that ever stops working the import guard below skips the module rather than
+erroring at collection time.
+"""
+
+import pytest
+
+try:
+    from statistics_txt_util import get_yules_k_i, tokenize, word_count
+except (ImportError, SystemExit):  # pragma: no cover - defensive
+    pytest.skip("statistics_txt_util dependencies not available", allow_module_level=True)
+
+
+def test_word_count():
+    assert word_count("the cat saw the dog") == {
+        "the": 2,
+        "cat": 1,
+        "saw": 1,
+        "dog": 1,
+    }
+
+
+def test_tokenize():
+    assert tokenize("it's a fine-day today") == ["it's", "a", "fine-day", "today"]
+
+
+def test_get_yules_k_i():
+    # Needs repeated tokens: all-distinct tokens make m2 == m1 and divide by zero.
+    k, i = get_yules_k_i("the cat and the dog and the bird")
+    assert k > 0
+    assert i > 0


### PR DESCRIPTION
## What

Seeds the legacy `src/` tree with its **first pytest suite** as a proof-of-concept, plus a GitHub Actions workflow that runs it on every push/PR.

The suite covers the pure, stdlib-only helpers in `src/statistics_txt_util.py` (document statistics):

- `word_count`
- `tokenize`
- `get_yules_k_i` (Yule's K/I lexical diversity)

## How it stays testable without refactoring

The legacy modules are GUI-coupled: importing `statistics_txt_util` pulls in `GUI_util` (which calls `tkinter.Tk()` at module load) and `IO_libraries_util.install_all_Python_packages` (which shells out to `pip`). Neither is acceptable in a unit test.

`tests/conftest.py` replaces those infra modules and the heavy NLP libraries (Stanza/spaCy/NLTK/pandas/…) with `MagicMock` stubs in `sys.modules` **before** the module under test is imported. This neutralises the import-time guards (`install_all_Python_packages(...) == False` becomes `False`, so the `sys.exit(0)` is skipped) without changing any production code. The stdlib modules the helpers actually use (`re`, `string`, `collections`) are left real.

## CI

`.github/workflows/tests.yml` runs `pytest tests/ -v` on push/PR to `current-stable`. Because the stubs make the suite hermetic and headless, the job only installs `pytest` — no NLP stack, runs in seconds.

```
tests/test_statistics_txt_util.py::test_word_count PASSED
tests/test_statistics_txt_util.py::test_tokenize PASSED
tests/test_statistics_txt_util.py::test_get_yules_k_i PASSED
3 passed in 0.06s
```

Also adds Python artifact patterns (`__pycache__/`, `*.py[cod]`, `.pytest_cache/`) to `.gitignore`.

## Notes

Scoped intentionally narrow as a POC — only the stdlib-pure helpers. End-to-end corpus tests would need the real Stanza stack and a cleaner import surface; this PR establishes the pattern that further tests can follow.