### PR TITLE
CTk migration Phase 0: unblock CTkImage under the portable bundle

### DIFF
--- a/docs/CustomTkinter-Migration-Plan.md
+++ b/docs/CustomTkinter-Migration-Plan.md
@@ -274,12 +274,25 @@ can't load `_imagingtk` (`invalid command name "PyImagingPhoto"` — the exact p
 (they draw with the canvas), but any code path we write that hands CTk a `CTkImage` will die in
 the bundle while working fine in a dev venv.
 
+**Phase 0 result (2026-07-15, macOS aarch64, cpython-3.10.15 python-build-standalone):**
+`tests/ctk_bundle_smoke.py` run under the bundled interpreter confirms CTk core is fine (root,
+Label/Button/OptionMenu/Frame, appearance toggle) but **raw `CTkImage` fails exactly as predicted**
+— `TypeError: bad argument type for built-in operation` from `PIL.ImageTk`. **Fix landed:**
+`ctk_bundle_util.patch_ctk_image_for_bundle()` monkeypatches the two `CTkImage` methods that touch
+ImageTk (`_get_scaled_light_photo_image` / `_get_scaled_dark_photo_image`) to build their Tk image
+through the same base64-PNG path as `GUI_util.tk_image_from_pil`. With the patch applied the smoke
+test is **green on Mac**; `CTkImage` is now usable in the bundle. ⏳ **Still pending: the same run on
+Windows** (different Tcl/Tk build) before Phase 0 is fully signed off.
+
 **Mitigations:**
-- Phase 0 ships a trivial CTk "hello" window and we run it **inside the built bundle** on both
-  OSes before committing to the migration.
-- Rule for the whole migration: images go through `tk_image_from_pil` → plain `PhotoImage`,
-  never `CTkImage`. Enforce with a grep in code review.
-- If the bundle smoke test fails for CTk itself (e.g., its font/scaling probing), the fallback
+- Phase 0 ships `tests/ctk_bundle_smoke.py` (CTk root, widgets, OptionMenu repopulation, **`CTkImage`
+  via the patch**, appearance toggle) and we run it **inside the built bundle** on both OSes before
+  committing to the migration.
+- Call `ctk_bundle_util.patch_ctk_image_for_bundle()` **once at startup, before any `CTkImage`**
+  (fold into the CTk bootstrap / `GUI_theme_util` init in Phase 1). It is idempotent and raises
+  loudly if a CustomTkinter upgrade moves the patched methods. This supersedes the earlier
+  "never use `CTkImage`" rule — with the patch, CTk's native image idiom is safe in the bundle.
+- If the bundle smoke test ever fails for CTk itself (e.g., its font/scaling probing), the fallback
   is to keep the bundled-app path on plain tk (runtime feature flag in `GUI_theme_util`:
   factories return tk widgets when CTk can't initialize) — the wrappers make this cheap.
 

--- a/src/ctk_bundle_util.py
+++ b/src/ctk_bundle_util.py
@@ -1,0 +1,82 @@
+"""CustomTkinter bundle compatibility shim (CTk migration — docs/CustomTkinter-Migration-Plan.md §5.1).
+
+CTk's ``CTkImage`` builds its Tk image with ``PIL.ImageTk.PhotoImage``. Under the portable
+python-build-standalone interpreter that ships in the NLP Suite installer, Tcl/Tk is *statically
+embedded*, so the ``_imagingtk`` C bridge cannot attach and every ``PIL.ImageTk`` call crashes
+(``TypeError: bad argument type for built-in operation`` / ``invalid command name "PyImagingPhoto"``).
+This is the same root cause that ``GUI_util.tk_image_from_pil`` was written to solve for the plain
+``tk.Label`` logo path, and the reason the matplotlib ``TkAgg`` backend had to fall back to ``Agg``.
+
+``patch_ctk_image_for_bundle()`` monkeypatches the two ``CTkImage`` methods that touch ImageTk so
+they hand Tk base64-encoded PNG bytes through the plain ``tk.PhotoImage(data=…)`` API instead —
+Tk 8.6 decodes PNG natively, and PIL is used only to resize/encode, never touching ``_imagingtk``.
+With the patch applied, ``CTkImage`` works under the bundle, so Phase 1+ can use CTk's native image
+idiom instead of banning ``CTkImage`` outright.
+
+Kept deliberately free of import-time side effects (no Tk root, no heavy imports) so the Phase 0
+bundle smoke test can import it under the standalone interpreter. Call ``patch_ctk_image_for_bundle()``
+once at startup, before any ``CTkImage`` is created.
+"""
+import base64
+import io
+import tkinter as tk
+
+_patched = False
+
+
+def _tk_photoimage_from_pil(pil_image):
+    """Build a plain ``tk.PhotoImage`` from a PIL image via base64 PNG, bypassing ``PIL.ImageTk``.
+
+    Mirror of ``GUI_util.tk_image_from_pil`` (kept local so this module imports without pulling in
+    GUI_util's Tk-root import side effects; see module docstring). Keep a reference to the returned
+    image — Tk does not.
+    """
+    if pil_image.mode not in ("RGB", "RGBA", "L", "LA", "P"):
+        pil_image = pil_image.convert("RGBA")
+    buffer = io.BytesIO()
+    pil_image.save(buffer, format="PNG")
+    return tk.PhotoImage(data=base64.b64encode(buffer.getvalue()))
+
+
+def patch_ctk_image_for_bundle():
+    """Route ``CTkImage``'s Tk-image construction through the base64-PNG path (see module docstring).
+
+    Idempotent. Returns True if the patch is in place, False if CustomTkinter is not importable.
+    Raises RuntimeError if CTkImage is present but its internals differ from what we patch (so a
+    CustomTkinter upgrade that moves these methods fails loudly at startup rather than crashing
+    later inside the bundle).
+    """
+    global _patched
+    if _patched:
+        return True
+
+    try:
+        from customtkinter.windows.widgets.image.ctk_image import CTkImage
+    except ImportError:
+        return False
+
+    if not (hasattr(CTkImage, "_get_scaled_light_photo_image")
+            and hasattr(CTkImage, "_get_scaled_dark_photo_image")):
+        raise RuntimeError(
+            "ctk_bundle_util: CTkImage internals changed; the bundle ImageTk workaround needs "
+            "updating (see docs/CustomTkinter-Migration-Plan.md §5.1)."
+        )
+
+    def _get_scaled_light_photo_image(self, scaled_size):
+        if scaled_size not in self._scaled_light_photo_images:
+            self._scaled_light_photo_images[scaled_size] = _tk_photoimage_from_pil(
+                self._light_image.resize(scaled_size)
+            )
+        return self._scaled_light_photo_images[scaled_size]
+
+    def _get_scaled_dark_photo_image(self, scaled_size):
+        if scaled_size not in self._scaled_dark_photo_images:
+            self._scaled_dark_photo_images[scaled_size] = _tk_photoimage_from_pil(
+                self._dark_image.resize(scaled_size)
+            )
+        return self._scaled_dark_photo_images[scaled_size]
+
+    CTkImage._get_scaled_light_photo_image = _get_scaled_light_photo_image
+    CTkImage._get_scaled_dark_photo_image = _get_scaled_dark_photo_image
+    _patched = True
+    return True

--- a/tests/ctk_bundle_smoke.py
+++ b/tests/ctk_bundle_smoke.py
@@ -4,8 +4,14 @@ GO / NO-GO gate: does CustomTkinter -- and specifically the PIL.ImageTk path use
 actually work under the interpreter that ships in the NLP Suite installer (python-build-standalone)?
 That interpreter has historically broken Tk-adjacent image handling: it is the reason
 GUI_util.tk_image_from_pil exists, and it is what crashed the matplotlib 'TkAgg' backend (fixed by
-falling back to 'Agg'). If CTkImage crashes here, the migration is DEAD-ON-ARRIVAL for the portable
-build -- which is the actual delivery channel to students -- and Phase 0 fails.
+falling back to 'Agg').
+
+RESULT (2026-07-15, macOS aarch64, cpython-3.10.15 python-build-standalone): raw CTkImage FAILS
+under the bundle exactly as predicted -- `TypeError: bad argument type for built-in operation` from
+PIL.ImageTk. The fix is ctk_bundle_util.patch_ctk_image_for_bundle(), which routes CTkImage's Tk
+image construction through the same base64-PNG path as GUI_util.tk_image_from_pil. This test applies
+that patch and verifies CTkImage then works, so the gate now checks the SHIPPING approach (patched).
+Without the patch the CTkImage check fails -- see docs/CustomTkinter-Migration-Plan.md §5.1.
 
 IMPORTANT: run this INSIDE the frozen bundle / with the BUNDLED interpreter (python-build-standalone),
 not just a dev Anaconda env -- a dev env passing tells you nothing about the bundle. It needs a real
@@ -15,7 +21,15 @@ _test suffix on purpose, so pytest won't collect it).
 Usage:  <bundled-python> tests/ctk_bundle_smoke.py
 Exit code 0 = PASS (all checks), non-zero = FAIL. Prints a per-check report.
 """
+# Standalone runtime probe: customtkinter/ctk_bundle_util are optional and loaded via a runtime
+# sys.path insert, and _ctk is a deliberately None-initialised module global. None of that is
+# statically resolvable, so scope off the two Pyright rules it trips.
+# pyright: reportMissingImports=false, reportOptionalMemberAccess=false
+import os
 import sys
+
+# Import the production shim from src/ without importing GUI_util (which builds a Tk root at import).
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'src'))
 
 _results = []
 _root = None
@@ -35,6 +49,9 @@ def _check(name, fn):
 def _import_and_root():
     global _root, _ctk
     import customtkinter as ctk
+    from ctk_bundle_util import patch_ctk_image_for_bundle
+    if not patch_ctk_image_for_bundle():   # apply the bundle ImageTk workaround before any CTkImage
+        raise RuntimeError('patch_ctk_image_for_bundle() reported CustomTkinter not importable')
     _ctk = ctk
     ctk.set_appearance_mode('light')
     _root = ctk.CTk()
@@ -53,7 +70,8 @@ def _basic_widgets():
 
 
 def _ctk_image():
-    # THE risk: CTkImage -> PIL.ImageTk, which is what python-build-standalone historically breaks.
+    # THE risk: CTkImage -> PIL.ImageTk, which python-build-standalone breaks. Passes only because
+    # patch_ctk_image_for_bundle() (applied in _import_and_root) reroutes it through base64 PNG.
     from PIL import Image
     img = Image.new('RGB', (16, 16), (200, 30, 30))
     cimg = _ctk.CTkImage(light_image=img, dark_image=img, size=(16, 16))
@@ -78,7 +96,7 @@ def main():
     _check('import customtkinter + create CTk root', _import_and_root)
     if _root is not None:
         _check('basic CTk widgets render (Label/Button/OptionMenu/Frame)', _basic_widgets)
-        _check('CTkImage via PIL.ImageTk (the python-build-standalone risk)', _ctk_image)
+        _check('CTkImage (patched: base64-PNG path, the python-build-standalone risk)', _ctk_image)
         _check('appearance mode light<->dark toggle', _appearance_toggle)
         _check('teardown (destroy root)', _teardown)
     ok = bool(_results) and all(p for _, p, _ in _results)


### PR DESCRIPTION
## What & why

Runs the Phase 0 bundle smoke test (`tests/ctk_bundle_smoke.py`) under the **shipped python-build-standalone interpreter** (cpython-3.10.15, macOS aarch64) and fixes the failure it surfaced.

**Result:** the §5.1 highest risk is real. Raw `CTkImage` crashes under the bundle with `TypeError: bad argument type for built-in operation` from `PIL.ImageTk` — that interpreter statically embeds Tcl/Tk, so the `_imagingtk` C bridge can't attach (same root cause `GUI_util.tk_image_from_pil` already exists for). CTk core (root, Label/Button/OptionMenu/Frame, appearance toggle) works fine.

## The fix

`src/ctk_bundle_util.py` → `patch_ctk_image_for_bundle()` monkeypatches the two `CTkImage` methods that touch ImageTk (`_get_scaled_light_photo_image` / `_get_scaled_dark_photo_image`) to build their Tk image through the same **base64-PNG → `tk.PhotoImage(data=…)`** path as `GUI_util.tk_image_from_pil`. Tk 8.6 decodes PNG natively; PIL only resizes/encodes, never touching `_imagingtk`.

- Idempotent; raises loudly if a CustomTkinter upgrade moves the patched methods.
- Kept free of import-time side effects so the standalone smoke test can import it under the bundle.
- **Call once at startup, before any `CTkImage`** (to be folded into the CTk bootstrap / `GUI_theme_util` init in Phase 1).

This **supersedes the plan's earlier "never use `CTkImage`" rule** — with the patch, CTk's native image idiom is safe in the bundle.

## Verification

Smoke test, run against the bundled interpreter — **all green on Mac** (was FAIL on the CTkImage check before the patch):

\`\`\`
CustomTkinter bundle smoke test — interpreter: 3.10.15
PASS  import customtkinter + create CTk root
PASS  basic CTk widgets render (Label/Button/OptionMenu/Frame)
PASS  CTkImage (patched: base64-PNG path, the python-build-standalone risk)
PASS  appearance mode light<->dark toggle
PASS  teardown (destroy root)
=== Phase 0 CustomTkinter bundle smoke test: PASS ===
\`\`\`

Ruff + Pyright clean on all changed files; `pytest` still does not collect the smoke test.

## Still pending

⏳ The same bundle run on **Windows** (different Tcl/Tk build) before Phase 0 is fully signed off.

## Notes

- Migration plan §5.1 updated with the result + the startup-call requirement.
- `docs/CustomTkinter-Migration-Plan.md` targets the `roberto` branch, which `build-installers.yml` checks out — so this correctly lands on `roberto`.
