### PR TITLE
CI: point tests workflow at roberto instead of current-stable

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,9 +2,9 @@ name: tests
 
 on:
   push:
-    branches: [current-stable]
+    branches: [roberto]
   pull_request:
-    branches: [current-stable]
+    branches: [roberto]
 
 jobs:
   pytest:


### PR DESCRIPTION
## Summary
- `.github/workflows/tests.yml` currently triggers on push/PR to `current-stable`, which is an older snapshot branch.
- `roberto` is now the integration/release branch that PRs land on, so CI should run there instead.

## Test plan
- [ ] Confirm the `tests` workflow triggers on a push/PR to `roberto` after merge.