### PR TITLE
CTk migration Phase 1 (1/2): GUI_theme_util compat layer + Phase 0 groundwork

### DIFF
--- a/NLP_Suite.spec
+++ b/NLP_Suite.spec
@@ -160,6 +160,9 @@ _third_party_hiddenimports = [
     'chardet', 'tqdm', 'psutil', 'json', 'csv', 'pickle',
     'collections', 'functools', 'itertools', 'statistics',
     'SPARQLWrapper',
+    # CustomTkinter GUI reskin (CTk migration). darkdetect is CTk's appearance-mode dep and is
+    # imported conditionally inside CTk, so PyInstaller needs it listed explicitly.
+    'customtkinter', 'darkdetect',
 ]
 
 # Collect stanza and spacy data files (language models etc.)
@@ -173,6 +176,12 @@ try:
 except Exception:
     _spacy_datas = []
 _nltk_datas = []  # nltk downloads data at runtime
+# CustomTkinter ships its own bundled color themes / assets that it loads at runtime
+# (set_default_color_theme, widget drawing); collect them so the reskin renders in the bundle.
+try:
+    _ctk_datas = collect_data_files('customtkinter')
+except Exception:
+    _ctk_datas = []
 
 # ── Data files to bundle ────────────────────────────────────────────────────
 # These are copied alongside the executable so the app can find them at runtime.
@@ -201,9 +210,12 @@ def _collect_tree(src_dir, dest_prefix):
 
 _project_datas = []
 
-# All src/*.py files (needed because GUIs check for .py files and some launch via subprocess)
+# All src/*.py files (needed because GUIs check for .py files and some launch via subprocess).
+# Also ship the CustomTkinter theme JSON (CTk migration): GUI_theme_util.init_appearance() loads
+# it from <exe>/src via GUI_IO_util.scriptPath, so it must sit alongside the .py files, not in
+# _internal (the .py-only filter would otherwise drop it).
 for f in os.listdir(SRC_DIR):
-    if f.endswith('.py') and not f.startswith('_'):
+    if (f.endswith('.py') or f == 'nlp_suite_theme.json') and not f.startswith('_'):
         _project_datas.append((os.path.join(SRC_DIR, f), 'src'))
 
 # Library data (recursive)
@@ -236,7 +248,7 @@ a = Analysis(
     [os.path.join(SRC_DIR, 'NLP_menu_main.py')],
     pathex=[SRC_DIR],
     binaries=[],
-    datas=_project_datas + _stanza_datas + _spacy_datas + _nltk_datas,
+    datas=_project_datas + _stanza_datas + _spacy_datas + _nltk_datas + _ctk_datas,
     hiddenimports=_local_modules + _third_party_hiddenimports,
     hookspath=[],
     hooksconfig={},

--- a/docs/CustomTkinter-Migration-Plan.md
+++ b/docs/CustomTkinter-Migration-Plan.md
@@ -72,8 +72,15 @@ through the plain `tk.PhotoImage(data=…)` API, bypassing `_imagingtk` entirely
 **This matters because CTk's `CTkImage` uses `PIL.ImageTk` internally.** See §5.1.
 
 Also: `Pillow` is pinned to `10.4.0` in `requirements.txt` because Pillow 12.x is incompatible
-with the bundled Tcl/Tk 8.6 runtime. CustomTkinter (5.2.x) is compatible with that pin — its
-only hard deps are `darkdetect` and `packaging`.
+with the bundled Tcl/Tk 8.6 runtime. CustomTkinter is compatible with that pin — its only hard
+dep is `darkdetect`.
+
+> **Version note (Phase 1):** the suite pins **`customtkinter==6.0.0`** — the version installed
+> in the dev/build environment and validated green by the Phase 0 bundle smoke test — *not* the
+> `5.2.x` this document first assumed. All widget-mapping and factory-wrapper work targets the
+> **6.0.0** API (e.g. `CTkLabel` has no `justify`, `CTkEntry` has neither `justify` nor `anchor`);
+> `GUI_theme_util.translate_kwargs` filters kwargs against each CTk class's real 6.0.0 signature
+> so this stays correct if the pin moves.
 
 ---
 
@@ -194,15 +201,26 @@ can coexist under a `CTk` root during the transition.
 
 ### Phase 0 — Groundwork (1 PR, small)
 
-- Add `customtkinter==5.2.*` (+ transitive `darkdetect`) to `requirements.txt`,
-  `requirements-mac.txt`, `requirements-windows.txt`, and the setup-app dependency probe
-  (`setup-app` scans source imports — verify it picks up `customtkinter`).
-- Add `nlp_suite_theme.json` (CTk color theme: accent `#b10a0a`, neutral grays) under
-  `src/` or `config/` so PyInstaller ships it.
+- Add `customtkinter==6.0.0` (+ transitive `darkdetect`) to `requirements.txt`, and the setup-app
+  dependency probe (`setup-app/Resources/environment_probe.py` scans source imports — once
+  `GUI_theme_util` `import customtkinter`, the probe requires it, which is why the pin lands here).
+  The per-OS `requirements-mac.txt` / `requirements-windows.txt` are installed *in addition* to the
+  base file, so the pin goes in `requirements.txt` **only** (adding it to all three would just
+  double-install).
+- Add `nlp_suite_theme.json` (CTk color theme: accent `#b10a0a`, neutral grays) under `src/` so
+  PyInstaller ships it (the spec's `src` collection is `.py`-only, so it needs an explicit datas
+  entry — done).
 - PyInstaller: add `collect_data_files('customtkinter')` to `NLP_Suite.spec` datas and
-  `darkdetect` to hiddenimports; same for `NetworkGraphViewer.spec` if it grows a CTk UI.
+  `customtkinter`/`darkdetect` to hiddenimports; same for `NetworkGraphViewer.spec` if it grows a
+  CTk UI.
 - **Bundle smoke test on both OSes before anything else lands** (see §5.1 — this is the
   make-or-break risk, so it goes first).
+
+> **Status (2026-07):** Phase 0's *bundle risk* work landed first (commits `19e490f2`, `24554889`:
+> `tests/ctk_bundle_smoke.py` + `src/ctk_bundle_util.py`). The remaining Phase 0 *groundwork* above
+> (requirements pin, theme JSON, spec datas/hiddenimports) was folded into **Phase 1 PR 1**
+> alongside `GUI_theme_util`, since that PR is the first thing to actually `import customtkinter`.
+> ⏳ Windows bundle smoke run still pending before Phase 0 is fully signed off (§5.1).
 
 ### Phase 1 — Shared framework (2–3 PRs, the heart of the migration)
 
@@ -333,8 +351,9 @@ hide real behavioral differences (e.g., different button texts fitting).
 
 ### 5.7 Version pins
 
-Pin `customtkinter==5.2.2` (or latest 5.2.x at Phase 0 time) in all three requirements files.
-Its deps must stay compatible with `Pillow==10.4.0` (they are — CTk does not require Pillow ≥11).
+Pin `customtkinter==6.0.0` (the version validated by the Phase 0 bundle smoke test) in
+`requirements.txt`. Its deps must stay compatible with `Pillow==10.4.0` (they are — CTk does not
+require Pillow ≥11). The base file is enough: the per-OS files install on top of it.
 
 ---
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -106,6 +106,12 @@ SPARQLWrapper
 
 # GUI
 tkcolorpicker
+# CustomTkinter GUI reskin (CTk migration -- docs/CustomTkinter-Migration-Plan.md). Pinned to the
+# version validated by the Phase 0 bundle smoke test (tests/ctk_bundle_smoke.py) under the portable
+# python-build-standalone interpreter; darkdetect is CTk's only hard runtime dep (pulled in
+# transitively). CTk 6.0.0 is compatible with the Pillow==10.4.0 pin above. Base-file only: the
+# per-OS requirements-mac/-windows files are installed *in addition* to this one.
+customtkinter==6.0.0
 
 # Auto-update via git
 pygit2

--- a/src/GUI_theme_util.py
+++ b/src/GUI_theme_util.py
@@ -29,6 +29,7 @@ wires ``GUI_util`` / ``GUI_IO_util`` onto it.
 
 import inspect
 import tkinter as tk
+import warnings
 
 import customtkinter as ctk
 
@@ -363,17 +364,27 @@ def init_appearance(appearance_mode="system"):
     Order matters: the bundle ImageTk patch (``ctk_bundle_util.patch_ctk_image_for_bundle``) must
     run before any CTkImage is built, and the color theme must be set before any widget is created
     (CTk snapshots theme colors at construction). Falls back to CTk's stock ``blue`` theme if the
-    NLP Suite theme file can't be found, so a missing data file degrades appearance instead of
-    crashing the launch.
+    NLP Suite theme file can't be found or fails to load, so a bad/missing data file degrades
+    appearance instead of crashing the launch -- but the failure is printed, NOT swallowed silently,
+    because a silent fallback previously hid a malformed-theme bug (CTk rejects a top-level JSON key
+    whose value is not a dict, e.g. a ``"_comment"`` string) that shipped the whole suite in blue.
     """
     global _initialized
     if _initialized:
         return
     ctk_bundle_util.patch_ctk_image_for_bundle()
     path = _theme_path()
-    try:
-        ctk.set_default_color_theme(path if path else "blue")
-    except Exception:
+    if path:
+        try:
+            ctk.set_default_color_theme(path)
+        except Exception as exc:
+            warnings.warn(
+                f"failed to load NLP Suite theme '{path}' ({exc}); falling back to the stock 'blue' theme.",
+                stacklevel=2,
+            )
+            ctk.set_default_color_theme("blue")
+    else:
+        warnings.warn("nlp_suite_theme.json not found; falling back to the stock 'blue' theme.", stacklevel=2)
         ctk.set_default_color_theme("blue")
     try:
         ctk.set_appearance_mode(appearance_mode)

--- a/src/GUI_theme_util.py
+++ b/src/GUI_theme_util.py
@@ -1,0 +1,382 @@
+"""GUI_theme_util -- CustomTkinter compatibility layer for the NLP Suite.
+
+Part of the CustomTkinter migration (docs/CustomTkinter-Migration-Plan.md, Phase 1). This module is
+the single place that owns CTk setup and the thin factory wrappers that let ~50 legacy GUI scripts
+stop calling ``tk.Button(...)`` / ``tk.OptionMenu(...)`` directly and instead call
+``GUI_theme_util.create_button(...)`` etc. The wrappers accept the *old tk-style keyword arguments*
+(character-based ``width=``, ``foreground=``, tk-only chrome like ``relief=``/``bd=``) and translate
+them to CustomTkinter equivalents (pixel-based ``width=``, ``text_color=``, unsupported kwargs
+dropped), so the mechanical per-file conversion in later phases is a near-verbatim call-site rename.
+
+Design notes
+------------
+* **Introspection-driven translation.** Rather than hand-maintaining a per-widget allow/deny list
+  (which drifts as CustomTkinter changes -- e.g. CTk 6.0.0's ``CTkLabel`` has no ``justify``, and
+  ``CTkEntry`` has neither ``justify`` nor ``anchor``), every wrapper filters the translated kwargs
+  against the *actual* accepted parameters of the target CTk class, read once via
+  ``inspect.signature``. A tk-only kwarg that has no CTk home is silently dropped rather than
+  crashing the constructor.
+* **Character widths -> pixels.** Legacy ``tk.Entry(width=30)`` means 30 characters;
+  ``CTkEntry(width=300)`` means 300 pixels. ``char_width_to_px`` / ``line_height_to_px`` do the
+  conversion (§5.2 of the plan). These are pure and unit-tested.
+* **No import-time side effects beyond importing CTk.** Loading a theme and setting the appearance
+  mode happen only when ``init_appearance()`` is called (from the CTk bootstrap in Phase 2's
+  GUI_util rewrite), never at import, so this module can be imported headlessly in tests.
+
+This module is a pure addition in Phase 1 PR 1: nothing in ``src/`` imports it yet. Phase 1 PR 2
+wires ``GUI_util`` / ``GUI_IO_util`` onto it.
+"""
+
+import inspect
+import tkinter as tk
+
+import customtkinter as ctk
+
+import ctk_bundle_util
+
+# NLP Suite brand accent (see GUI_util.py "RGB red is #b10a0a"). Mirrored in nlp_suite_theme.json.
+NLP_SUITE_ACCENT = "#b10a0a"
+
+# Legacy tk widths are in characters; CTk widths are in pixels. Rough average glyph advance for the
+# suite's UI font. Tuned once here; per-call-site tweaks happen during the pilot/batch phases.
+_PX_PER_CHAR = 8
+# Legacy tk heights (buttons/labels/text) are in text lines; CTk heights are in pixels.
+_PX_PER_LINE = 22
+# A CTk widget's natural (default) height, used as the floor when translating small line counts.
+_MIN_WIDGET_PX = 28
+# Above this, an incoming height/width is assumed to already be pixels (a CTk-aware caller), not
+# a legacy line/character count, so it is passed through unchanged.
+_ALREADY_PX_THRESHOLD = 60
+
+# tk keyword -> CTk keyword renames. (Colors: tk ``foreground``/``fg`` -> CTk ``text_color``.)
+_RENAME = {
+    "foreground": "text_color",
+    "fg": "text_color",
+}
+
+# tk keywords that describe native-widget chrome CTk draws itself (or the theme owns). Dropped
+# outright so they never reach a CTk constructor even if some future CTk class grows a like-named
+# parameter with different semantics. Background colors are dropped rather than mapped to
+# ``fg_color`` so a legacy ``bg='SystemButtonFace'`` can't stomp the themed accent.
+_DROP = frozenset(
+    {
+        "bg",
+        "background",
+        "activebackground",
+        "activeforeground",
+        "disabledforeground",
+        "highlightbackground",
+        "highlightcolor",
+        "highlightthickness",
+        "bd",
+        "borderwidth",
+        "relief",
+        "overrelief",
+        "offrelief",
+        "selectcolor",
+        "indicatoron",
+        "padx",
+        "pady",
+        "takefocus",
+        "repeatdelay",
+        "repeatinterval",
+        "cursor",
+        "underline",
+        "default",
+        "wraplength",  # tk wraplength is in pixels but rarely matched to CTk metrics; let CTk reflow.
+    }
+)
+
+
+def char_width_to_px(char_width, px_per_char=_PX_PER_CHAR, padding=0):
+    """Translate a legacy tk character-based width into a CTk pixel width.
+
+    Returns ``None`` for a missing / non-positive / non-numeric width so the caller can drop the
+    ``width`` kwarg entirely and let CTk use its own default sizing.
+    """
+    try:
+        n = int(char_width)
+    except (TypeError, ValueError):
+        return None
+    if n <= 0:
+        return None
+    if n > _ALREADY_PX_THRESHOLD:
+        return n  # already pixels (CTk-aware caller)
+    return n * px_per_char + padding
+
+
+def line_height_to_px(char_height):
+    """Translate a legacy tk line-based height (e.g. a 2-line RUN button) into a CTk pixel height.
+
+    Returns ``None`` for a missing / non-positive / non-numeric height so the caller drops the
+    ``height`` kwarg and CTk uses its default widget height.
+    """
+    try:
+        n = int(char_height)
+    except (TypeError, ValueError):
+        return None
+    if n <= 0:
+        return None
+    if n > _ALREADY_PX_THRESHOLD:
+        return n  # already pixels
+    return max(_MIN_WIDGET_PX, n * _PX_PER_LINE)
+
+
+def _accepted_params(cls):
+    """The set of keyword parameters ``cls.__init__`` accepts (minus self/master/*args/**kwargs)."""
+    params = inspect.signature(cls.__init__).parameters
+    return {
+        name
+        for name, p in params.items()
+        if name not in ("self", "master", "args", "kwargs") and p.kind not in (p.VAR_POSITIONAL, p.VAR_KEYWORD)
+    }
+
+
+def translate_kwargs(cls, kwargs, width_is_chars=True, height_is_lines=True):
+    """Translate legacy tk widget kwargs into kwargs valid for CustomTkinter class ``cls``.
+
+    Pure function (no widget is created), so it is unit-testable against the real CTk classes via
+    signature introspection without a display. Rules:
+
+    * ``foreground``/``fg`` -> ``text_color``.
+    * ``width`` (characters) -> pixels via :func:`char_width_to_px` when ``width_is_chars``.
+    * ``height`` (lines) -> pixels via :func:`line_height_to_px` when ``height_is_lines``.
+    * native-tk chrome kwargs (``relief``, ``bd``, ``bg``, ...) are dropped.
+    * anything the target CTk class does not accept is dropped (never passed through blindly).
+    """
+    accepted = _accepted_params(cls)
+    out = {}
+    for key, value in kwargs.items():
+        if key in _DROP:
+            continue
+        if key == "width" and width_is_chars:
+            value = char_width_to_px(value)
+            if value is None:
+                continue
+        elif key == "height" and height_is_lines:
+            value = line_height_to_px(value)
+            if value is None:
+                continue
+        key = _RENAME.get(key, key)
+        if key in accepted:
+            out[key] = value
+        # else: a tk-only kwarg with no CTk equivalent -- drop it silently.
+    return out
+
+
+# ---------------------------------------------------------------------------------------------
+# Widget factories. Each mirrors the tk constructor call signature its call sites already use
+# (master first, then keyword args) so the mechanical conversion is a name swap.
+# ---------------------------------------------------------------------------------------------
+
+
+def create_button(master, **kwargs):
+    return ctk.CTkButton(master, **translate_kwargs(ctk.CTkButton, kwargs))
+
+
+def create_label(master, **kwargs):
+    return ctk.CTkLabel(master, **translate_kwargs(ctk.CTkLabel, kwargs))
+
+
+def create_entry(master, **kwargs):
+    # tk.Entry has no height; only width is character-based.
+    return ctk.CTkEntry(master, **translate_kwargs(ctk.CTkEntry, kwargs, height_is_lines=False))
+
+
+def create_checkbox(master, **kwargs):
+    return ctk.CTkCheckBox(master, **translate_kwargs(ctk.CTkCheckBox, kwargs))
+
+
+def create_option_menu(master, variable=None, values=None, command=None, **kwargs):
+    """tk.OptionMenu(master, var, *choices) -> CTkOptionMenu(master, variable=, values=[...]).
+
+    The legacy call passes the choices as varargs; call sites converting to this factory pass them
+    as ``values=[...]``. Repopulate a live menu with :func:`set_values` (never the old
+    ``widget["menu"]`` mutation).
+    """
+    translated = translate_kwargs(ctk.CTkOptionMenu, kwargs)
+    if variable is not None:
+        translated["variable"] = variable
+    if values is not None:
+        translated["values"] = list(values)
+    if command is not None:
+        translated["command"] = command
+    return ctk.CTkOptionMenu(master, **translated)
+
+
+def create_combobox(master, values=None, **kwargs):
+    translated = translate_kwargs(ctk.CTkComboBox, kwargs)
+    if values is not None:
+        translated["values"] = list(values)
+    return ctk.CTkComboBox(master, **translated)
+
+
+def create_slider(master, from_=None, to=None, length=None, orient=None, resolution=None, **kwargs):
+    """tk.Scale(...) -> CTkSlider(...).
+
+    Maps the tk names CTk renamed: ``length`` (px long dimension) -> ``width``, ``orient`` ->
+    ``orientation``, and ``resolution`` (step size) -> ``number_of_steps`` when a range is known.
+    CTkSlider has no built-in value label; call sites that need one add a small CTkLabel bound to
+    the same variable (the legacy ``slider_widget`` popup already does this by hand).
+    """
+    translated = translate_kwargs(ctk.CTkSlider, kwargs, width_is_chars=False, height_is_lines=False)
+    if from_ is not None:
+        translated["from_"] = from_
+    if to is not None:
+        translated["to"] = to
+    if length is not None:
+        translated["width"] = length
+    if orient is not None:
+        translated["orientation"] = orient
+    if resolution and from_ is not None and to is not None:
+        try:
+            steps = int(round((float(to) - float(from_)) / float(resolution)))
+            if steps > 0:
+                translated["number_of_steps"] = steps
+        except (TypeError, ValueError, ZeroDivisionError):
+            pass
+    return ctk.CTkSlider(master, **translated)
+
+
+def create_textbox(master, **kwargs):
+    # tk.Text width is characters, height is lines; CTkTextbox has a built-in scrollbar so the
+    # manual tk.Scrollbar pairing at the call site is dropped during conversion.
+    return ctk.CTkTextbox(master, **translate_kwargs(ctk.CTkTextbox, kwargs))
+
+
+def set_values(widget, values, default=None):
+    """Repopulate a CTkOptionMenu / CTkComboBox's items -- the CTk replacement for the legacy
+    ``menu = widget["menu"]; menu.delete(0, "end"); menu.add_command(...)`` idiom.
+
+    Pass ``default`` to also select an item (e.g. the first) after repopulating. Returns the
+    normalized list actually set.
+    """
+    values = list(values)
+    widget.configure(values=values)
+    if default is not None:
+        widget.set(default)
+    return values
+
+
+class ToolTip:
+    """Lightweight hover tooltip bound to a widget's ``<Enter>``/``<Leave>`` events.
+
+    Replaces the coordinate-based ``GUI_IO_util.hover_over_widget`` / ``display_widget_info``
+    machinery, which reconstructed popup positions from the same absolute pixel constants the grid
+    migration removes. Bind to the widget itself instead; the ``text`` strings (the suite's main
+    in-app documentation) are preserved verbatim by the callers. The tooltip surface is a plain
+    ``tk.Toplevel`` (the classic yellow tip), which renders fine under a CTk root and needs no CTk
+    theming of its own.
+    """
+
+    def __init__(self, widget, text, delay_ms=500, wraplength=420):
+        self.widget = widget
+        self.text = text or ""
+        self.delay_ms = delay_ms
+        self.wraplength = wraplength
+        self._after_id = None
+        self._tip = None
+        widget.bind("<Enter>", self._schedule, add="+")
+        widget.bind("<Leave>", self._hide, add="+")
+        widget.bind("<ButtonPress>", self._hide, add="+")
+
+    def _schedule(self, _event=None):
+        self._cancel()
+        if self.text:
+            self._after_id = self.widget.after(self.delay_ms, self._show)
+
+    def _cancel(self):
+        if self._after_id is not None:
+            try:
+                self.widget.after_cancel(self._after_id)
+            except Exception:
+                pass
+            self._after_id = None
+
+    def _show(self):
+        if self._tip is not None or not self.text:
+            return
+        try:
+            x = self.widget.winfo_rootx() + 20
+            y = self.widget.winfo_rooty() + self.widget.winfo_height() + 8
+        except Exception:
+            return
+        self._tip = tip = tk.Toplevel(self.widget)
+        tip.wm_overrideredirect(True)
+        tip.wm_geometry(f"+{x}+{y}")
+        label = tk.Label(
+            tip,
+            text=self.text,
+            justify="left",
+            background="#ffffe0",
+            foreground="#000000",
+            relief="solid",
+            borderwidth=1,
+            wraplength=self.wraplength,
+        )
+        label.pack(ipadx=4, ipady=3)
+
+    def _hide(self, _event=None):
+        self._cancel()
+        if self._tip is not None:
+            try:
+                self._tip.destroy()
+            except Exception:
+                pass
+            self._tip = None
+
+
+def _theme_path():
+    """Absolute path to nlp_suite_theme.json, or ``None`` if it can't be located.
+
+    Resolves through ``GUI_IO_util.scriptPath`` (which is frozen-bundle aware -- the theme ships to
+    ``<exe>/src`` via NLP_Suite.spec) and falls back to this module's own directory for a dev
+    checkout. Imported lazily so this module has no import-time dependency on GUI_IO_util (which the
+    unit-test harness stubs).
+    """
+    import os
+
+    candidates = []
+    try:
+        import GUI_IO_util
+
+        candidates.append(os.path.join(GUI_IO_util.scriptPath, "nlp_suite_theme.json"))
+    except Exception:
+        pass
+    candidates.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), "nlp_suite_theme.json"))
+    for path in candidates:
+        try:
+            if os.path.isfile(path):
+                return path
+        except Exception:
+            pass
+    return None
+
+
+_initialized = False
+
+
+def init_appearance(appearance_mode="system"):
+    """One-time, idempotent CustomTkinter bootstrap. Call once at startup, before creating any CTk
+    widget or CTkImage.
+
+    Order matters: the bundle ImageTk patch (``ctk_bundle_util.patch_ctk_image_for_bundle``) must
+    run before any CTkImage is built, and the color theme must be set before any widget is created
+    (CTk snapshots theme colors at construction). Falls back to CTk's stock ``blue`` theme if the
+    NLP Suite theme file can't be found, so a missing data file degrades appearance instead of
+    crashing the launch.
+    """
+    global _initialized
+    if _initialized:
+        return
+    ctk_bundle_util.patch_ctk_image_for_bundle()
+    path = _theme_path()
+    try:
+        ctk.set_default_color_theme(path if path else "blue")
+    except Exception:
+        ctk.set_default_color_theme("blue")
+    try:
+        ctk.set_appearance_mode(appearance_mode)
+    except Exception:
+        pass
+    _initialized = True

--- a/src/nlp_suite_theme.json
+++ b/src/nlp_suite_theme.json
@@ -1,5 +1,4 @@
 {
-  "_comment": "NLP Suite CustomTkinter color theme (CTk migration -- docs/CustomTkinter-Migration-Plan.md). Brand accent red #b10a0a (see GUI_util.py 'RGB red is #b10a0a'). Neutral grays are CTk's stock light/dark pairs; only the accent-bearing widgets are recolored red. Each color is a [light-mode, dark-mode] pair. Loaded via GUI_theme_util.init_appearance() -> customtkinter.set_default_color_theme().",
   "CTk": {
     "fg_color": ["gray92", "gray14"]
   },

--- a/src/nlp_suite_theme.json
+++ b/src/nlp_suite_theme.json
@@ -1,0 +1,158 @@
+{
+  "_comment": "NLP Suite CustomTkinter color theme (CTk migration -- docs/CustomTkinter-Migration-Plan.md). Brand accent red #b10a0a (see GUI_util.py 'RGB red is #b10a0a'). Neutral grays are CTk's stock light/dark pairs; only the accent-bearing widgets are recolored red. Each color is a [light-mode, dark-mode] pair. Loaded via GUI_theme_util.init_appearance() -> customtkinter.set_default_color_theme().",
+  "CTk": {
+    "fg_color": ["gray92", "gray14"]
+  },
+  "CTkToplevel": {
+    "fg_color": ["gray92", "gray14"]
+  },
+  "CTkFrame": {
+    "corner_radius": 6,
+    "border_width": 0,
+    "fg_color": ["gray86", "gray17"],
+    "top_fg_color": ["gray81", "gray20"],
+    "border_color": ["gray65", "gray28"]
+  },
+  "CTkButton": {
+    "corner_radius": 6,
+    "border_width": 0,
+    "fg_color": ["#b10a0a", "#c81414"],
+    "hover_color": ["#8a0808", "#9e0d0d"],
+    "border_color": ["#3E454A", "#949A9F"],
+    "text_color": ["#FFFFFF", "#F5E9E9"],
+    "text_color_disabled": ["gray74", "gray60"]
+  },
+  "CTkLabel": {
+    "corner_radius": 0,
+    "border_width": 0,
+    "fg_color": "transparent",
+    "border_color": ["#979DA2", "#565B5E"],
+    "text_color": ["gray10", "#DCE4EE"]
+  },
+  "CTkEntry": {
+    "corner_radius": 6,
+    "border_width": 2,
+    "fg_color": ["#F9F9FA", "#343638"],
+    "border_color": ["#979DA2", "#565B5E"],
+    "text_color": ["gray10", "#DCE4EE"],
+    "placeholder_text_color": ["gray52", "gray62"]
+  },
+  "CTkCheckBox": {
+    "corner_radius": 6,
+    "border_width": 3,
+    "fg_color": ["#b10a0a", "#c81414"],
+    "border_color": ["#3E454A", "#949A9F"],
+    "hover_color": ["#8a0808", "#9e0d0d"],
+    "checkmark_color": ["#FFFFFF", "gray90"],
+    "text_color": ["gray10", "#DCE4EE"],
+    "text_color_disabled": ["gray60", "gray45"]
+  },
+  "CTkSwitch": {
+    "corner_radius": 1000,
+    "border_width": 3,
+    "button_length": 0,
+    "fg_color": ["#939BA2", "#4A4D50"],
+    "progress_color": ["#b10a0a", "#c81414"],
+    "button_color": ["gray36", "#D5D9DE"],
+    "button_hover_color": ["gray20", "gray100"],
+    "text_color": ["gray10", "#DCE4EE"],
+    "text_color_disabled": ["gray60", "gray45"]
+  },
+  "CTkRadioButton": {
+    "corner_radius": 1000,
+    "border_width_checked": 6,
+    "border_width_unchecked": 3,
+    "fg_color": ["#b10a0a", "#c81414"],
+    "border_color": ["#3E454A", "#949A9F"],
+    "hover_color": ["#8a0808", "#9e0d0d"],
+    "text_color": ["gray10", "#DCE4EE"],
+    "text_color_disabled": ["gray60", "gray45"]
+  },
+  "CTkProgressBar": {
+    "corner_radius": 1000,
+    "border_width": 0,
+    "fg_color": ["#939BA2", "#4A4D50"],
+    "progress_color": ["#b10a0a", "#c81414"],
+    "border_color": ["gray", "gray"]
+  },
+  "CTkSlider": {
+    "corner_radius": 1000,
+    "button_corner_radius": 1000,
+    "border_width": 6,
+    "button_length": 0,
+    "fg_color": ["#939BA2", "#4A4D50"],
+    "progress_color": ["gray40", "#AAB0B5"],
+    "button_color": ["#b10a0a", "#c81414"],
+    "button_hover_color": ["#8a0808", "#9e0d0d"]
+  },
+  "CTkOptionMenu": {
+    "corner_radius": 6,
+    "fg_color": ["#b10a0a", "#c81414"],
+    "button_color": ["#8a0808", "#9e0d0d"],
+    "button_hover_color": ["#6d0606", "#7a0a0a"],
+    "text_color": ["#FFFFFF", "#F5E9E9"],
+    "text_color_disabled": ["gray74", "gray60"]
+  },
+  "CTkComboBox": {
+    "corner_radius": 6,
+    "border_width": 2,
+    "fg_color": ["#F9F9FA", "#343638"],
+    "border_color": ["#979DA2", "#565B5E"],
+    "button_color": ["#b10a0a", "#c81414"],
+    "button_hover_color": ["#8a0808", "#9e0d0d"],
+    "text_color": ["gray10", "#DCE4EE"],
+    "text_color_disabled": ["gray50", "gray45"]
+  },
+  "CTkScrollbar": {
+    "corner_radius": 1000,
+    "border_spacing": 4,
+    "fg_color": "transparent",
+    "button_color": ["gray55", "gray41"],
+    "button_hover_color": ["gray40", "gray53"]
+  },
+  "CTkSegmentedButton": {
+    "corner_radius": 6,
+    "border_width": 2,
+    "fg_color": ["#979DA2", "gray29"],
+    "selected_color": ["#b10a0a", "#c81414"],
+    "selected_hover_color": ["#8a0808", "#9e0d0d"],
+    "unselected_color": ["#979DA2", "gray29"],
+    "unselected_hover_color": ["gray70", "gray41"],
+    "text_color": ["#FFFFFF", "#F5E9E9"],
+    "text_color_disabled": ["gray74", "gray60"]
+  },
+  "CTkTextbox": {
+    "corner_radius": 6,
+    "border_width": 0,
+    "fg_color": ["#F9F9FA", "#1D1E1E"],
+    "border_color": ["#979DA2", "#565B5E"],
+    "text_color": ["gray10", "#DCE4EE"],
+    "scrollbar_button_color": ["gray55", "gray41"],
+    "scrollbar_button_hover_color": ["gray40", "gray53"]
+  },
+  "CTkScrollableFrame": {
+    "label_fg_color": ["gray78", "gray23"]
+  },
+  "DropdownMenu": {
+    "fg_color": ["gray90", "gray20"],
+    "hover_color": ["#b10a0a", "#c81414"],
+    "text_color": ["gray10", "gray90"]
+  },
+  "CTkFont": {
+    "macOS": {
+      "family": "SF Display",
+      "size": 13,
+      "weight": "normal"
+    },
+    "Windows": {
+      "family": "Roboto",
+      "size": 13,
+      "weight": "normal"
+    },
+    "Linux": {
+      "family": "Roboto",
+      "size": 13,
+      "weight": "normal"
+    }
+  }
+}

--- a/tests/test_gui_theme_util.py
+++ b/tests/test_gui_theme_util.py
@@ -1,0 +1,137 @@
+"""Unit tests for GUI_theme_util -- the CustomTkinter compatibility layer (CTk migration Phase 1).
+
+Covers the *pure* logic: the character/line -> pixel width translation, the tk-kwargs -> CTk-kwargs
+translation (validated against the real CustomTkinter 6.0.0 class signatures via introspection, no
+display needed), and the ``set_values`` menu-repopulation helper. Widget construction and the
+ToolTip surface need a live Tk display and are exercised by tests/gui_smoke.py, not here.
+
+customtkinter is import-skipped so the suite still collects on a box without it installed.
+"""
+
+import pytest
+
+ctk = pytest.importorskip("customtkinter")
+
+import GUI_theme_util as gtu  # noqa: E402  (import after importorskip on purpose)
+
+
+# ── char_width_to_px ─────────────────────────────────────────────────────────
+class TestCharWidthToPx:
+    def test_basic_chars_to_pixels(self):
+        assert gtu.char_width_to_px(10) == 10 * gtu._PX_PER_CHAR
+
+    def test_custom_px_per_char_and_padding(self):
+        assert gtu.char_width_to_px(5, px_per_char=10, padding=4) == 54
+
+    @pytest.mark.parametrize("bad", [0, -3, None, "", "abc"])
+    def test_missing_or_nonpositive_returns_none(self, bad):
+        assert gtu.char_width_to_px(bad) is None
+
+    def test_large_value_treated_as_already_pixels(self):
+        # A CTk-aware caller passing a real pixel width must not be multiplied again.
+        assert gtu.char_width_to_px(300) == 300
+
+    def test_numeric_string_is_accepted(self):
+        assert gtu.char_width_to_px("12") == 12 * gtu._PX_PER_CHAR
+
+
+# ── line_height_to_px ────────────────────────────────────────────────────────
+class TestLineHeightToPx:
+    def test_single_line_floors_to_min_widget_px(self):
+        assert gtu.line_height_to_px(1) == gtu._MIN_WIDGET_PX
+
+    def test_two_line_button_taller_than_min(self):
+        assert gtu.line_height_to_px(2) == max(gtu._MIN_WIDGET_PX, 2 * gtu._PX_PER_LINE)
+
+    @pytest.mark.parametrize("bad", [0, -1, None, "x"])
+    def test_missing_or_nonpositive_returns_none(self, bad):
+        assert gtu.line_height_to_px(bad) is None
+
+    def test_large_value_treated_as_already_pixels(self):
+        assert gtu.line_height_to_px(440) == 440
+
+
+# ── translate_kwargs (against real CTk 6.0.0 signatures) ─────────────────────
+class TestTranslateKwargs:
+    def test_foreground_and_fg_rename_to_text_color(self):
+        assert gtu.translate_kwargs(ctk.CTkButton, {"foreground": "red"}) == {"text_color": "red"}
+        assert gtu.translate_kwargs(ctk.CTkButton, {"fg": "red"}) == {"text_color": "red"}
+
+    def test_width_translated_to_pixels(self):
+        out = gtu.translate_kwargs(ctk.CTkEntry, {"width": 30})
+        assert out == {"width": 30 * gtu._PX_PER_CHAR}
+
+    def test_height_translated_to_pixels(self):
+        out = gtu.translate_kwargs(ctk.CTkButton, {"height": 2})
+        assert out["height"] == max(gtu._MIN_WIDGET_PX, 2 * gtu._PX_PER_LINE)
+
+    def test_entry_height_not_line_translated_when_flag_off(self):
+        # create_entry passes height_is_lines=False; a raw pixel height must survive unchanged.
+        out = gtu.translate_kwargs(ctk.CTkEntry, {"height": 40}, height_is_lines=False)
+        assert out["height"] == 40
+
+    def test_zero_width_is_dropped_not_zeroed(self):
+        # width<=0 -> None -> drop, so CTk keeps its own default sizing rather than a 0px widget.
+        assert "width" not in gtu.translate_kwargs(ctk.CTkButton, {"width": 0})
+
+    def test_native_tk_chrome_dropped(self):
+        out = gtu.translate_kwargs(
+            ctk.CTkButton,
+            {
+                "relief": "raised",
+                "bd": 2,
+                "borderwidth": 2,
+                "bg": "white",
+                "highlightthickness": 0,
+                "activebackground": "gray",
+            },
+        )
+        assert out == {}
+
+    def test_unsupported_ctk_kwarg_dropped(self):
+        # CTk 6.0.0 CTkLabel has no `justify`; it must be dropped, not passed to the constructor.
+        assert "justify" not in gtu.translate_kwargs(ctk.CTkLabel, {"justify": "left"})
+        # ...but CTkComboBox *does* accept justify, so there it survives.
+        assert gtu.translate_kwargs(ctk.CTkComboBox, {"justify": "left"}) == {"justify": "left"}
+
+    def test_accepted_passthrough_preserved(self):
+        out = gtu.translate_kwargs(ctk.CTkButton, {"text": "RUN", "state": "disabled"})
+        assert out == {"text": "RUN", "state": "disabled"}
+
+    def test_text_color_wins_over_dropped_bg(self):
+        out = gtu.translate_kwargs(ctk.CTkButton, {"foreground": "red", "bg": "white"})
+        assert out == {"text_color": "red"}
+
+
+# ── set_values ───────────────────────────────────────────────────────────────
+class _FakeMenu:
+    def __init__(self):
+        self.configured = None
+        self.selected = None
+
+    def configure(self, **kwargs):
+        self.configured = kwargs
+
+    def set(self, value):
+        self.selected = value
+
+
+class TestSetValues:
+    def test_configures_values_and_returns_list(self):
+        w = _FakeMenu()
+        result = gtu.set_values(w, ("a", "b", "c"))
+        assert w.configured == {"values": ["a", "b", "c"]}
+        assert result == ["a", "b", "c"]
+        assert w.selected is None  # no default -> selection untouched
+
+    def test_default_selects_item(self):
+        w = _FakeMenu()
+        gtu.set_values(w, ["x", "y"], default="x")
+        assert w.selected == "x"
+
+
+# ── _accepted_params sanity ──────────────────────────────────────────────────
+def test_accepted_params_excludes_self_and_varargs():
+    params = gtu._accepted_params(ctk.CTkButton)
+    assert "self" not in params and "master" not in params
+    assert "text" in params and "command" in params

--- a/tests/test_gui_theme_util.py
+++ b/tests/test_gui_theme_util.py
@@ -135,3 +135,27 @@ def test_accepted_params_excludes_self_and_varargs():
     params = gtu._accepted_params(ctk.CTkButton)
     assert "self" not in params and "master" not in params
     assert "text" in params and "command" in params
+
+
+# ── the theme JSON actually loads and applies the accent (regression) ─────────
+# CTk's load_theme requires every top-level key to be a dict (it does theme[key].keys()); a stray
+# "_comment" string key raised AttributeError and silently fell back to CTk's blue theme, shipping
+# the whole suite in blue. This test loads the real file and asserts the accent red is applied.
+def test_theme_json_loads_and_applies_accent():
+    import json
+    import os
+
+    theme_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "src", "nlp_suite_theme.json")
+    assert os.path.isfile(theme_path), "nlp_suite_theme.json must ship in src/"
+
+    # Every top-level value must be a dict, or CTk's load_theme raises on theme[key].keys().
+    data = json.loads(open(theme_path, encoding="utf-8").read())
+    non_dict = [k for k, v in data.items() if not isinstance(v, dict)]
+    assert not non_dict, f"top-level theme keys must all be dicts; offenders: {non_dict}"
+
+    # Load for real through CTk and confirm the brand red reached CTkButton (not the blue fallback).
+    ctk.set_default_color_theme(theme_path)
+    from customtkinter import ThemeManager
+
+    button_fg = ThemeManager.theme["CTkButton"]["fg_color"]
+    assert gtu.NLP_SUITE_ACCENT in button_fg, f"expected accent {gtu.NLP_SUITE_ACCENT} in {button_fg}"


### PR DESCRIPTION
**Stack:** this is **PR 1 of 2** for Phase 1 of the [CustomTkinter migration plan](../blob/roberto/docs/CustomTkinter-Migration-Plan.md). PR 2 (`ctk/phase1-core`, the `GUI_util` + `GUI_IO_util` rewrite) is stacked on top of this branch and is where the reskin becomes click-testable.

## What this PR is
The shared **compat layer** that lets ~50 legacy GUI scripts stop calling `tk.Button(...)` / `tk.OptionMenu(...)` directly. It lands as a **pure addition — nothing in `src/` imports it yet**, so the suite's behavior is unchanged at this merge point. That's deliberate: it makes this PR safe to review as groundwork, with the risky wiring isolated in PR 2.

## Contents
**`src/GUI_theme_util.py`** — the layer:
- `init_appearance()` — idempotent one-time CTk bootstrap: runs the Phase 0 bundle ImageTk patch (`ctk_bundle_util.patch_ctk_image_for_bundle`) **before any CTkImage**, loads the theme (falls back to CTk stock `blue` if the data file is missing), sets appearance mode.
- **Factory wrappers** (`create_button/label/entry/checkbox/option_menu/combobox/slider/textbox`) that accept the **old tk-style kwargs** and translate to CTk 6.0.0 — so later phases are a near-verbatim call-site rename.
- `translate_kwargs()` — **introspection-driven**: filters kwargs against each CTk class's *real* 6.0.0 `__init__` signature (e.g. `CTkLabel` has no `justify`, `CTkEntry` has neither `justify` nor `anchor`), renames `foreground`/`fg` → `text_color`, converts character widths / line heights → pixels (plan §5.2), drops native-tk chrome (`relief`/`bd`/`bg`/…). A tk-only kwarg with no CTk home is **dropped, never passed through to crash the constructor**.
- `set_values()` — the CTk replacement for the legacy `widget["menu"]` OptionMenu-mutation idiom.
- `ToolTip` — hover tooltip bound to the widget itself, replacing `hover_over_widget`'s coordinate-based popup (the grid migration in PR 2 removes the absolute coords it depended on).

**`src/nlp_suite_theme.json`** — CTk color theme: brand accent red `#b10a0a` over CTk's neutral gray light/dark pairs; only accent-bearing widgets are recolored.

**Phase 0 groundwork** that never landed with the bundle-risk work (#1638), folded in here since this is the first module to `import customtkinter`:
- `requirements.txt`: pin **`customtkinter==6.0.0`** — the version the Phase 0 bundle smoke test validated green, **not** the plan's stale `5.2.x`. Base file only (the per-OS files install on top of it).
- `NLP_Suite.spec`: `customtkinter`/`darkdetect` hiddenimports, `collect_data_files('customtkinter')`, and ship `nlp_suite_theme.json` to `<exe>/src` (the spec's `src` collection was `.py`-only).
- `docs/CustomTkinter-Migration-Plan.md`: correct `5.2.x` → `6.0.0` throughout; record what landed where.

## Testing
- **`tests/test_gui_theme_util.py`** (28 cases): the pure logic — char/line→px translation and `translate_kwargs` validated against the **real CTk 6.0.0 class signatures** (no display needed). `customtkinter` is import-skipped so collection still works without it.
- Full suite green: **31 passed**.
- Live end-to-end construction of **every** factory widget verified under a real `CTk()` root (legacy kwargs like `width=10, height=2, relief='raised', bd=2` → correct pixel sizing, dropped chrome; slider step conversion; `set_values` repopulation).
- Ruff (lint + format) clean, Pyright 0 errors on touched files.

## Notes for review
- No GUI (`*_main.py`) changes → `tests/gui_smoke.py` is unaffected by this PR.
- ⏳ The Windows bundle smoke run (plan §5.1) is still the one open Phase 0 item; it gates final sign-off, not this layer's correctness.