### PR TITLE
CTk migration Phase 1 slice 2: GUI_util + GUI_IO_util

### DIFF
--- a/docs/CustomTkinter-Migration-Plan.md
+++ b/docs/CustomTkinter-Migration-Plan.md
@@ -235,7 +235,7 @@ can coexist under a `CTk` root during the transition.
 > **Status (2026-07):** PR 1 (`GUI_theme_util` compat layer + Phase 0 groundwork) merged to
 > `roberto` as **PR #1641**. PR 2 (root → `CTk()`, shared-chrome factory conversions, `GUI_top`
 > intro widget, kept the `.place()` layout — "slice 2a") lives on `ctk/phase1-core`, opened
-> against `roberto` as **fork PR #2** now that PR 1 has landed there. It includes the
+> against `roberto` as **PR #1645** now that PR 1 has landed there. It includes the
 > folder-icon open-button fix (the "open selected file/directory" buttons were rendering as
 > empty ~8px slivers — `width=1, text=''` — fixed via a new `GUI_theme_util.create_open_file_button`
 > themed `CTkButton`) and the logo-column tightening (logo 85×50 → 58×34, column-0 minsize

--- a/docs/CustomTkinter-Migration-Plan.md
+++ b/docs/CustomTkinter-Migration-Plan.md
@@ -232,6 +232,26 @@ can coexist under a `CTk` root during the transition.
    `place_help_button`; `message_box_widget`, `enter_value_widget`, `slider_widget`,
    `dropdown_menu_widget*`, `combobox_with_search_widget` popups → CTkToplevel + wrappers.
 
+> **Status (2026-07):** PR 1 (`GUI_theme_util` compat layer + Phase 0 groundwork) merged to
+> `roberto` as **PR #1641**. PR 2 (root → `CTk()`, shared-chrome factory conversions, `GUI_top`
+> intro widget, kept the `.place()` layout — "slice 2a") lives on `ctk/phase1-core`, opened
+> against `roberto` as **fork PR #2** now that PR 1 has landed there. It includes the
+> folder-icon open-button fix (the "open selected file/directory" buttons were rendering as
+> empty ~8px slivers — `width=1, text=''` — fixed via a new `GUI_theme_util.create_open_file_button`
+> themed `CTkButton`) and the logo-column tightening (logo 85×50 → 58×34, column-0 minsize
+> 210 → 122), moved here from the grid-reflow branch since both are chrome/theming fixes
+> independent of the grid engine itself.
+>
+> `placeWidget` → `grid()` ("slice 2b") lives on `ctk/phase1-grid`, stacked on `ctk/phase1-core`
+> as **fork PR #3**. First render is clean on `statistics_csv_main` and the suite is green, but
+> it's still WIP — open punch-list items: window geometry is tuned to the old absolute layout
+> (~35% empty on the right); `IO_config_setup_brief()` creates a duplicate INPUT display box
+> (two ~450px boxes render side by side, a major overflow driver, flagged with a
+> `TODO(ctk-migration)`); `NLP_menu_main`'s `ttk.Notebook` is still `.place()`d over the gridded
+> chrome and needs special-casing; multi-column GUIs (SVO, GIS) and the raw-`.place()` GUIs
+> (`data_visualization_main.py`, 140 sites) are unvalidated; and the per-GUI click-test list
+> (widest/busiest rows, the `sameY` path, notebook GUIs, baseline sanity) is still outstanding.
+
 After Phase 1, **every GUI already looks substantially better** (new chrome, themed top/bottom
 bars, help column, scrollable body) even though its own widgets are still plain tk.
 

--- a/src/GUI_IO_util.py
+++ b/src/GUI_IO_util.py
@@ -222,6 +222,23 @@ def hover_over_widget(window, x_coordinate, y_coordinate, widget_name, no_hover_
                     whole_widget_red=False, x_coordinate_hover_over= 90, text_info=''):
     if no_hover_over_widget:
         return
+
+    # CTk migration (Phase 1 slice 2a): CustomTkinter widgets draw themselves and do NOT support
+    # tk's .cget('background') / .config(background=...) -- the red/green color-flip machinery below
+    # would raise on them. CTk widgets already have a built-in hover_color, so they need no color
+    # flip: give them a TOOLTIP-ONLY hover (show text_info on <Enter>, dismiss on <Leave>/click),
+    # then return before the tk-specific code. The tk path below is untouched for plain tk widgets.
+    if 'customtkinter' in type(widget_name).__module__:
+        if text_info != '':
+            number_of_lines = text_info.count('\n')
+            y_offset = 20 if number_of_lines == 0 else (25 if number_of_lines == 1 else 30)
+            tip_y = y_coordinate - y_offset
+            widget_name.bind('<Enter>', lambda e: display_widget_info(
+                window, e, x_coordinate, tip_y, x_coordinate_hover_over, text_info), add='+')
+            widget_name.bind('<Leave>', lambda e: delete_display_widget_lb(window, e, text_info), add='+')
+            widget_name.bind('<Button>', lambda e: delete_display_widget_lb(window, e, text_info), add='+')
+        return
+
     # hover-over effect
     # background = 'red' sets the whole widget in red
     # background='#F0F0F0' sets the widget in grey

--- a/src/GUI_IO_util.py
+++ b/src/GUI_IO_util.py
@@ -111,7 +111,9 @@ remindersPath = os.path.join(NLPPath, 'reminders')
 # The function places and displays a message for each ? HELP button in the GUIs
 def place_help_button(window,x_coordinate,y_coordinate,text_title,text_info):
     import GUI_theme_util
-    help_button = GUI_theme_util.create_button(window, text='? HELP', command=lambda: display_help_button_info(text_title, text_info))
+    # Give '? HELP' an explicit character width so CTk doesn't fall back to its 140px default
+    # (which makes every help button look oversized). 10 chars matches the Read Me/RUN chrome buttons.
+    help_button = GUI_theme_util.create_button(window, text='? HELP', width=10, command=lambda: display_help_button_info(text_title, text_info))
     # place widget with hover-over info
     y_multiplier_integer = placeWidget(window, x_coordinate,
                                                    y_coordinate,

--- a/src/GUI_IO_util.py
+++ b/src/GUI_IO_util.py
@@ -110,7 +110,8 @@ remindersPath = os.path.join(NLPPath, 'reminders')
 
 # The function places and displays a message for each ? HELP button in the GUIs
 def place_help_button(window,x_coordinate,y_coordinate,text_title,text_info):
-    help_button = tk.Button(window, text='? HELP', command=lambda: display_help_button_info(text_title, text_info))
+    import GUI_theme_util
+    help_button = GUI_theme_util.create_button(window, text='? HELP', command=lambda: display_help_button_info(text_title, text_info))
     # place widget with hover-over info
     y_multiplier_integer = placeWidget(window, x_coordinate,
                                                    y_coordinate,

--- a/src/GUI_theme_util.py
+++ b/src/GUI_theme_util.py
@@ -175,6 +175,28 @@ def create_button(master, **kwargs):
     return ctk.CTkButton(master, **translate_kwargs(ctk.CTkButton, kwargs))
 
 
+# The small "open the selected file / directory" affordance. The legacy `width=1, text=''` rendered
+# these as ~8px empty slivers (the red bars / gray box users read as broken). A folder glyph plus a
+# real width makes them read as buttons. Kept in one place so the glyph can be swapped in a single
+# edit if a platform's Tk font renders emoji as a tofu box (fallback: '...').
+OPEN_FILE_GLYPH = '\U0001F4C2'  # 📂
+
+
+def create_open_file_button(master, command=None, width=32, **kwargs):
+    """Small themed icon button for the 'open selected file/directory' action.
+
+    Built directly on CTkButton (not via :func:`create_button`) so ``width`` is honoured as pixels:
+    the char->px translation in ``create_button`` treats any width <= 60 as a character count, so a
+    ~30px icon button can't be expressed through it. Any leftover legacy ``text``/``width`` kwargs
+    are dropped in favour of the fixed glyph and the pixel width.
+    """
+    kwargs.pop('text', None)
+    kwargs.pop('width', None)
+    translated = translate_kwargs(ctk.CTkButton, kwargs)
+    translated['width'] = width
+    return ctk.CTkButton(master, text=OPEN_FILE_GLYPH, command=command, **translated)
+
+
 def create_label(master, **kwargs):
     return ctk.CTkLabel(master, **translate_kwargs(ctk.CTkLabel, kwargs))
 

--- a/src/GUI_util.py
+++ b/src/GUI_util.py
@@ -858,7 +858,10 @@ def IO_config_setup_brief(window, y_multiplier_integer, config_filename, scriptN
     # else:
     #     config_filename = config_filename_selected_config.get()
     # setup button to open a pop-up text entry widget where users can paste text to be used instead of an input file
-    openTextWidget_button = GUI_theme_util.create_button(window, width=GUI_IO_util.open_file_directory_button_width, text='',
+    # Give this its own width + label: it was an empty width=1 button (~8px under CTk, a thin red
+    # sliver) even though it opens a paste-text popup for a quick test run -- unlike the adjacent
+    # open_file_directory buttons, it has no neighbouring field to give it context.
+    openTextWidget_button = GUI_theme_util.create_button(window, width=12, text='Paste text',
                                       command=open_paste_text_popup)
     # place widget with hover-over info
     y_multiplier_integer = GUI_IO_util.placeWidget(window,GUI_IO_util.setup_pop_up_text_widget, y_multiplier_integer,

--- a/src/GUI_util.py
+++ b/src/GUI_util.py
@@ -886,28 +886,28 @@ def IO_config_setup_brief(window, y_multiplier_integer, config_filename, scriptN
     # setup buttons to open an input file, an input directory, an output directory, and a csv config file
     x_coordinate_hover_over = GUI_IO_util.IO_configuration_menu+GUI_IO_util.open_file_button_brief
     # setup a button to open an input file
-    openInputFile_button = GUI_theme_util.create_button(window, width=GUI_IO_util.open_file_directory_button_width, text='',
+    openInputFile_button = GUI_theme_util.create_open_file_button(window,
                                      command=lambda:IO_files_util.open_file_removing_date_from_filename(window,inputFilename.get(),True))
     # place widget with hover-over info
     y_multiplier_integer = GUI_IO_util.placeWidget(window,GUI_IO_util.IO_configuration_menu+GUI_IO_util.open_file_button_brief, y_multiplier_integer,
                                                    openInputFile_button, True, False, True, False, 90, x_coordinate_hover_over, "Open INPUT file")
 
     # setup a button to open Windows Explorer on the selected INPUT directory
-    openInputDirectory_button = GUI_theme_util.create_button(window, width=GUI_IO_util.open_file_directory_button_width, text='',
+    openInputDirectory_button = GUI_theme_util.create_open_file_button(window,
                                      command=lambda: IO_files_util.open_directory_removing_date_from_directory(window,input_main_dir_path.get(),True))
     # place widget with hover-over info
     y_multiplier_integer = GUI_IO_util.placeWidget(window,GUI_IO_util.IO_configuration_menu+GUI_IO_util.open_inputDir_button_brief, y_multiplier_integer,
                                                    openInputDirectory_button, True, False, True,False, 90, x_coordinate_hover_over, "Open INPUT files directory")
 
     # setup a button to open Windows Explorer on the selected OUTPUT directory
-    openOutputDirectory_button = GUI_theme_util.create_button(window, width=GUI_IO_util.open_file_directory_button_width, text='',
+    openOutputDirectory_button = GUI_theme_util.create_open_file_button(window,
                                      command=lambda: IO_files_util.openExplorer(window, output_dir_path.get()))
     # place widget with hover-over info
     y_multiplier_integer = GUI_IO_util.placeWidget(window,GUI_IO_util.IO_configuration_menu+GUI_IO_util.open_outputDir_button_brief, y_multiplier_integer,
                                                    openOutputDirectory_button, True, False, True,False, 90, x_coordinate_hover_over, "Open OUTPUT files directory")
 
     # Open csv config file
-    openInputConfigFile_button = GUI_theme_util.create_button(window, width=GUI_IO_util.open_file_directory_button_width, text='',
+    openInputConfigFile_button = GUI_theme_util.create_open_file_button(window,
                                      command=lambda: openConfigFile(config_filename_selected_config.get()))
     # place widget with hover-over info
     y_multiplier_integer = GUI_IO_util.placeWidget(window,GUI_IO_util.IO_configuration_menu+GUI_IO_util.open_config_file_button_brief, y_multiplier_integer,
@@ -956,7 +956,7 @@ def IO_config_setup_full (window, y_multiplier_integer):
         y_multiplier_integer = GUI_IO_util.placeWidget(window,GUI_IO_util.labels_x_coordinate,y_multiplier_integer,select_inputFilename_button,True)
 
         #setup a button to open Windows Explorer on the selected input file
-        openInputFile_button  = GUI_theme_util.create_button(window, width=GUI_IO_util.open_file_directory_button_width, text='',
+        openInputFile_button  = GUI_theme_util.create_open_file_button(window,
                             command=lambda: IO_files_util.open_file_removing_date_from_filename(window,inputFilename.get(),True))
         y_multiplier_integer = GUI_IO_util.placeWidget(window,
             GUI_IO_util.IO_configuration_menu, y_multiplier_integer,
@@ -985,8 +985,8 @@ def IO_config_setup_full (window, y_multiplier_integer):
         y_multiplier_integer = GUI_IO_util.placeWidget(window,GUI_IO_util.labels_x_coordinate,y_multiplier_integer,select_input_main_dir_button,True)
 
         #setup a button to open Windows Explorer on the selected main input directory
-        openDirectory_button  = GUI_theme_util.create_button(window, width=GUI_IO_util.open_file_directory_button_width,
-                            text='', command=lambda: IO_files_util.open_directory_removing_date_from_directory(window,input_main_dir_path.get(),True))
+        openDirectory_button  = GUI_theme_util.create_open_file_button(window,
+                            command=lambda: IO_files_util.open_directory_removing_date_from_directory(window,input_main_dir_path.get(),True))
         y_multiplier_integer = GUI_IO_util.placeWidget(window,
             GUI_IO_util.IO_configuration_menu,
             y_multiplier_integer,
@@ -1014,7 +1014,7 @@ def IO_config_setup_full (window, y_multiplier_integer):
                             y_multiplier_integer,select_input_secondary_dir_button,True)
 
         #setup a button to open Windows Explorer on the selected secondary input directory
-        openDirectory_button  = GUI_theme_util.create_button(window, width=GUI_IO_util.open_file_directory_button_width, text='', command=lambda: IO_files_util.openExplorer(window, input_secondary_dir_path.get()))
+        openDirectory_button  = GUI_theme_util.create_open_file_button(window, command=lambda: IO_files_util.openExplorer(window, input_secondary_dir_path.get()))
         y_multiplier_integer = GUI_IO_util.placeWidget(window,
             GUI_IO_util.IO_configuration_menu,
             y_multiplier_integer,
@@ -1032,7 +1032,7 @@ def IO_config_setup_full (window, y_multiplier_integer):
 
         #setup a button to open Windows Explorer on the selected input directory
         # current_y_multiplier_integer4=y_multiplier_integer-1
-        openDirectory_button  = GUI_theme_util.create_button(window, width=GUI_IO_util.open_file_directory_button_width, text='', command=lambda: IO_files_util.openExplorer(window, output_dir_path.get()))
+        openDirectory_button  = GUI_theme_util.create_open_file_button(window, command=lambda: IO_files_util.openExplorer(window, output_dir_path.get()))
         y_multiplier_integer = GUI_IO_util.placeWidget(window,
             GUI_IO_util.IO_configuration_menu,
             y_multiplier_integer,

--- a/src/GUI_util.py
+++ b/src/GUI_util.py
@@ -18,7 +18,19 @@ import IO_libraries_util
 #     sys.exit(0)
 
 import tkinter as tk
-window = tk.Tk()
+
+# CTk migration (docs/CustomTkinter-Migration-Plan.md, Phase 1): the shared root window becomes a
+# CustomTkinter root so the whole suite renders themed. init_appearance() MUST run first -- it
+# applies the Phase 0 bundle ImageTk patch and loads the NLP Suite color theme BEFORE any widget is
+# created (CTk snapshots theme colors at construction time). tk / ttk widgets still parent to this
+# root unchanged (CTk() is a tkinter.Tk subclass), so the rest of the migration proceeds
+# incrementally on top of this. Appearance is pinned to "light" for now: while the individual GUI
+# widgets are still plain tk/ttk, "system"/dark would render a jarring half-dark UI -- the
+# appearance-mode toggle lands once the widgets themselves are CTk (plan Phase 5).
+import customtkinter as ctk
+import GUI_theme_util
+GUI_theme_util.init_appearance("light")
+window = ctk.CTk()
 from sys import platform
 
 import os

--- a/src/GUI_util.py
+++ b/src/GUI_util.py
@@ -190,7 +190,7 @@ config_input_output_alphabetic_options=[]
 setup_IO_menu_var = tk.StringVar()
 # https://stackoverflow.com/questions/42222626/tkinter-option-menu-widget-add-command-lambda-does-not-produce-expected-command
 ###
-setup_IO_menu = tk.OptionMenu(window, setup_IO_menu_var, 'Default I/O configuration', 'Select any I/O csv config file')
+setup_IO_menu = GUI_theme_util.create_option_menu(window, variable=setup_IO_menu_var, values=['Default I/O configuration', 'Select any I/O csv config file'])
 
 IO_setup_var = tk.StringVar()
 IO_setup_brief_display_area = None
@@ -1327,8 +1327,8 @@ def display_setup_hover_over(y_multiplier_integer):
     hover_over_x_coordinate, hover_over_info = get_hover_over_info(package_display_area_value)
 
     # lay the setup widget
-    setup_menu_lb = tk.OptionMenu(window, setup_menu, "Setup preferences", "Setup NLP package (parsers & annotators) and corpus language",
-                                  "Setup external software")
+    setup_menu_lb = GUI_theme_util.create_option_menu(window, variable=setup_menu, values=["Setup preferences", "Setup NLP package (parsers & annotators) and corpus language",
+                                  "Setup external software"])
 
     if y_multiplier_integer_SV == 0:
         y_multiplier_integer_SV = y_multiplier_integer
@@ -1465,7 +1465,7 @@ def GUI_bottom(config_filename, config_input_output_numeric_options, y_multiplie
             not 'NLP_menu_main' in scriptName and \
             not "NLP_setup_" in scriptName:
         #open output csv files widget defined above since it is used earlier
-        open_csv_output_label = tk.Checkbutton(window, variable=open_csv_output_checkbox, onvalue=1, offvalue=0, command=lambda: trace_checkbox(open_csv_output_label, open_csv_output_checkbox, "Open output files", "Do NOT open output files"))
+        open_csv_output_label = GUI_theme_util.create_checkbox(window, variable=open_csv_output_checkbox, onvalue=1, offvalue=0, command=lambda: trace_checkbox(open_csv_output_label, open_csv_output_checkbox, "Open output files", "Do NOT open output files"))
         open_csv_output_label.configure(text="Open output files")
         y_multiplier_integer = GUI_IO_util.placeWidget(window,GUI_IO_util.labels_x_coordinate,
                                                        y_multiplier_integer,
@@ -1491,7 +1491,7 @@ def GUI_bottom(config_filename, config_input_output_numeric_options, y_multiplie
         charts_package_options = ['No charts','Excel','Python Plotly (dynamic)','Python Plotly (static)']
         # TODO EXCEL widget (same as open reminders)
         charts_package_options_widget.set('Excel')
-        charts_package_menu_lb = tk.OptionMenu(window,charts_package_options_widget,*charts_package_options)
+        charts_package_menu_lb = GUI_theme_util.create_option_menu(window, variable=charts_package_options_widget, values=charts_package_options)
         y_multiplier_integer = GUI_IO_util.placeWidget(window,GUI_IO_util.open_TIPS_x_coordinate,
                                                        y_multiplier_integer,
                                                        charts_package_menu_lb,
@@ -1509,7 +1509,7 @@ def GUI_bottom(config_filename, config_input_output_numeric_options, y_multiplie
                                    'Comparative bar charts (Open GUI)', 'Geographic maps (Open GUI)', 'Gephi (Open GUI)', 'Sankey flowchart (Open GUI)', 'Sunburst chart (Open GUI)',
                                    'Time mapper (Open GUI)', 'Treemap chart (Open GUI)', 'Wordcloud (Open GUI)']
         charts_type_options_widget.set('Bar chart')
-        charts_type_menu_lb = tk.OptionMenu(window,charts_type_options_widget,*charts_type_options)
+        charts_type_menu_lb = GUI_theme_util.create_option_menu(window, variable=charts_type_options_widget, values=charts_type_options)
         # place widget with hover-over info
         y_multiplier_integer = GUI_IO_util.placeWidget(window,GUI_IO_util.open_reminders_x_coordinate,
                                                        y_multiplier_integer,
@@ -1520,7 +1520,7 @@ def GUI_bottom(config_filename, config_input_output_numeric_options, y_multiplie
 
         data_transformation_options=['No transformation','Normalize by document size', 'Ln','Log','Square rooot','Z score']
         data_transformation_options_widget.set('No transformation')
-        data_transformation_menu_lb = tk.OptionMenu(window,data_transformation_options_widget,*data_transformation_options)
+        data_transformation_menu_lb = GUI_theme_util.create_option_menu(window, variable=data_transformation_options_widget, values=data_transformation_options)
         # place widget with hover-over info
         y_multiplier_integer = GUI_IO_util.placeWidget(window,GUI_IO_util.open_setup_x_coordinate,
                                                        y_multiplier_integer,
@@ -1546,7 +1546,7 @@ def GUI_bottom(config_filename, config_input_output_numeric_options, y_multiplie
         # if not 'data_manipulation_main.py' in scriptName and not 'data_visualization_1_main.py' in scriptName :
         data_tools_options = ['Data/corpus sampling', 'Data manipulation', 'Data statistics', 'Data visualization']
         data_tools_options_widget.set('Data tools')
-        data_tools_menu_lb = tk.OptionMenu(window, data_tools_options_widget, *data_tools_options)
+        data_tools_menu_lb = GUI_theme_util.create_option_menu(window, variable=data_tools_options_widget, values=data_tools_options)
         # place widget with hover-over info
         y_multiplier_integer = GUI_IO_util.placeWidget(window, GUI_IO_util.run_button_x_coordinate,
                                                        y_multiplier_integer,
@@ -1591,13 +1591,11 @@ def GUI_bottom(config_filename, config_input_output_numeric_options, y_multiplie
     videos_dropdown_field.set('Watch videos')
     if len(videos_lookup)==1:
         if videos_options == "No videos available":
-            videos_menu_lb = tk.OptionMenu(window, videos_dropdown_field, videos_options)
+            videos_menu_lb = GUI_theme_util.create_option_menu(window, variable=videos_dropdown_field, values=[videos_options])
         else:
-            videos_menu_lb = tk.OptionMenu(window, videos_dropdown_field, videos_options)
-            videos_menu_lb.configure(foreground="red")
+            videos_menu_lb = GUI_theme_util.create_option_menu(window, variable=videos_dropdown_field, values=[videos_options])
     else:
-        videos_menu_lb = tk.OptionMenu(window,videos_dropdown_field,*videos_options)
-        videos_menu_lb.configure(foreground="red")
+        videos_menu_lb = GUI_theme_util.create_option_menu(window, variable=videos_dropdown_field, values=videos_options)
     # place widget with hover-over info
     y_multiplier_integer = GUI_IO_util.placeWidget(window, GUI_IO_util.watch_videos_x_coordinate,
                                                    y_multiplier_integer,
@@ -1616,13 +1614,11 @@ def GUI_bottom(config_filename, config_input_output_numeric_options, y_multiplie
     tips_dropdown_field.set('Open TIPS files')
     if len(TIPS_lookup)==1:
         if TIPS_options == "No TIPS available":
-            tips_menu_lb = tk.OptionMenu(window, tips_dropdown_field, TIPS_options)
+            tips_menu_lb = GUI_theme_util.create_option_menu(window, variable=tips_dropdown_field, values=[TIPS_options])
         else:
-            tips_menu_lb = tk.OptionMenu(window, tips_dropdown_field, TIPS_options)
-            tips_menu_lb.configure(foreground="red")
+            tips_menu_lb = GUI_theme_util.create_option_menu(window, variable=tips_dropdown_field, values=[TIPS_options])
     else:
-        tips_menu_lb = tk.OptionMenu(window,tips_dropdown_field,*TIPS_options)
-        tips_menu_lb.configure(foreground="red")
+        tips_menu_lb = GUI_theme_util.create_option_menu(window, variable=tips_dropdown_field, values=TIPS_options)
     # place widget with hover-over info
     y_multiplier_integer = GUI_IO_util.placeWidget(window, GUI_IO_util.open_TIPS_x_coordinate,
                                                    y_multiplier_integer,
@@ -1652,19 +1648,17 @@ def GUI_bottom(config_filename, config_input_output_numeric_options, y_multiplie
     # reminders content for specific GUIs are set in the csv file reminders
     # called from any GUI
     reminders_dropdown_field.set('Open reminders')
-    reminders_menu_lb = tk.OptionMenu(window,  reminders_dropdown_field,"No Reminders available")
+    reminders_menu_lb = GUI_theme_util.create_option_menu(window, variable=reminders_dropdown_field, values=["No Reminders available"])
 
     if len(reminder_options)==0:
         reminder_options = ["No Reminders available"]
     if len(reminder_options)==0 or len(reminder_options)==1:
         if reminder_options == ["No Reminders available"]:
-            reminders_menu_lb = tk.OptionMenu(window, reminders_dropdown_field, *reminder_options)
+            reminders_menu_lb = GUI_theme_util.create_option_menu(window, variable=reminders_dropdown_field, values=reminder_options)
         else:
-            reminders_menu_lb = tk.OptionMenu(window, reminders_dropdown_field, *reminder_options)
-            reminders_menu_lb.configure(foreground="red")
+            reminders_menu_lb = GUI_theme_util.create_option_menu(window, variable=reminders_dropdown_field, values=reminder_options)
     else:
-        reminders_menu_lb = tk.OptionMenu(window,reminders_dropdown_field,*reminder_options)
-        reminders_menu_lb.configure(foreground="red")
+        reminders_menu_lb = GUI_theme_util.create_option_menu(window, variable=reminders_dropdown_field, values=reminder_options)
     # place widget with hover-over info
     y_multiplier_integer = GUI_IO_util.placeWidget(window, GUI_IO_util.open_reminders_x_coordinate,
                                                    y_multiplier_integer,

--- a/src/GUI_util.py
+++ b/src/GUI_util.py
@@ -227,7 +227,7 @@ reminders_dropdown_field = tk.StringVar()
 setup_menu = tk.StringVar()
 data_tools_options_widget = tk.StringVar()
 
-run_button = tk.Button(window, text='RUN', width=10,height=2)
+run_button = GUI_theme_util.create_button(window, text='RUN', width=10,height=2)
 
 # license agreement GUI
 agreement_checkbox_var=tk.IntVar()
@@ -829,7 +829,7 @@ def openConfigFile(config_filename):
 # this is the Setup INPUT/OUTPUT configuration
 def IO_config_setup_brief(window, y_multiplier_integer, config_filename, scriptName, silent):
     global IO_setup_brief_display_area
-    IO_setup_button = tk.Button(window, width=GUI_IO_util.select_file_directory_button_width, text='Setup INPUT/OUTPUT configuration',
+    IO_setup_button = GUI_theme_util.create_button(window, width=GUI_IO_util.select_file_directory_button_width, text='Setup INPUT/OUTPUT configuration',
                 command=lambda: setup_IO_configuration_options(True, scriptName, silent=True, open_setup_IO_GUI=True))
     # place widget with hover-over info
     y_multiplier_integer = GUI_IO_util.placeWidget(window, GUI_IO_util.labels_x_coordinate,
@@ -858,7 +858,7 @@ def IO_config_setup_brief(window, y_multiplier_integer, config_filename, scriptN
     # else:
     #     config_filename = config_filename_selected_config.get()
     # setup button to open a pop-up text entry widget where users can paste text to be used instead of an input file
-    openTextWidget_button = tk.Button(window, width=GUI_IO_util.open_file_directory_button_width, text='',
+    openTextWidget_button = GUI_theme_util.create_button(window, width=GUI_IO_util.open_file_directory_button_width, text='',
                                       command=open_paste_text_popup)
     # place widget with hover-over info
     y_multiplier_integer = GUI_IO_util.placeWidget(window,GUI_IO_util.setup_pop_up_text_widget, y_multiplier_integer,
@@ -883,28 +883,28 @@ def IO_config_setup_brief(window, y_multiplier_integer, config_filename, scriptN
     # setup buttons to open an input file, an input directory, an output directory, and a csv config file
     x_coordinate_hover_over = GUI_IO_util.IO_configuration_menu+GUI_IO_util.open_file_button_brief
     # setup a button to open an input file
-    openInputFile_button = tk.Button(window, width=GUI_IO_util.open_file_directory_button_width, text='',
+    openInputFile_button = GUI_theme_util.create_button(window, width=GUI_IO_util.open_file_directory_button_width, text='',
                                      command=lambda:IO_files_util.open_file_removing_date_from_filename(window,inputFilename.get(),True))
     # place widget with hover-over info
     y_multiplier_integer = GUI_IO_util.placeWidget(window,GUI_IO_util.IO_configuration_menu+GUI_IO_util.open_file_button_brief, y_multiplier_integer,
                                                    openInputFile_button, True, False, True, False, 90, x_coordinate_hover_over, "Open INPUT file")
 
     # setup a button to open Windows Explorer on the selected INPUT directory
-    openInputDirectory_button = tk.Button(window, width=GUI_IO_util.open_file_directory_button_width, text='',
+    openInputDirectory_button = GUI_theme_util.create_button(window, width=GUI_IO_util.open_file_directory_button_width, text='',
                                      command=lambda: IO_files_util.open_directory_removing_date_from_directory(window,input_main_dir_path.get(),True))
     # place widget with hover-over info
     y_multiplier_integer = GUI_IO_util.placeWidget(window,GUI_IO_util.IO_configuration_menu+GUI_IO_util.open_inputDir_button_brief, y_multiplier_integer,
                                                    openInputDirectory_button, True, False, True,False, 90, x_coordinate_hover_over, "Open INPUT files directory")
 
     # setup a button to open Windows Explorer on the selected OUTPUT directory
-    openOutputDirectory_button = tk.Button(window, width=GUI_IO_util.open_file_directory_button_width, text='',
+    openOutputDirectory_button = GUI_theme_util.create_button(window, width=GUI_IO_util.open_file_directory_button_width, text='',
                                      command=lambda: IO_files_util.openExplorer(window, output_dir_path.get()))
     # place widget with hover-over info
     y_multiplier_integer = GUI_IO_util.placeWidget(window,GUI_IO_util.IO_configuration_menu+GUI_IO_util.open_outputDir_button_brief, y_multiplier_integer,
                                                    openOutputDirectory_button, True, False, True,False, 90, x_coordinate_hover_over, "Open OUTPUT files directory")
 
     # Open csv config file
-    openInputConfigFile_button = tk.Button(window, width=GUI_IO_util.open_file_directory_button_width, text='',
+    openInputConfigFile_button = GUI_theme_util.create_button(window, width=GUI_IO_util.open_file_directory_button_width, text='',
                                      command=lambda: openConfigFile(config_filename_selected_config.get()))
     # place widget with hover-over info
     y_multiplier_integer = GUI_IO_util.placeWidget(window,GUI_IO_util.IO_configuration_menu+GUI_IO_util.open_config_file_button_brief, y_multiplier_integer,
@@ -932,28 +932,28 @@ def IO_config_setup_full (window, y_multiplier_integer):
         # buttons are set to normal or disabled in selectFile_set_options
         if config_input_output_numeric_options[0]==1: #single CoNLL file
             # buttons are set to normal or disabled in selectFile_set_options
-            select_inputFilename_button=tk.Button(window, width=GUI_IO_util.select_file_directory_button_width, text='Select INPUT CoNLL table', command=lambda: selectFile_set_options(window,True,True,inputFilename,input_main_dir_path,'Select INPUT CoNLL table (csv file)',[('CoNLL csv file','.csv')],".csv"))
+            select_inputFilename_button=GUI_theme_util.create_button(window, width=GUI_IO_util.select_file_directory_button_width, text='Select INPUT CoNLL table', command=lambda: selectFile_set_options(window,True,True,inputFilename,input_main_dir_path,'Select INPUT CoNLL table (csv file)',[('CoNLL csv file','.csv')],".csv"))
         elif config_input_output_numeric_options[0]==2: #single txt file:
             # buttons are set to normal or disabled in selectFile_set_options
-            select_inputFilename_button=tk.Button(window, width=GUI_IO_util.select_file_directory_button_width, text='Select INPUT TXT file', command=lambda: selectFile_set_options(window,True,False,inputFilename,input_main_dir_path,'Select INPUT TXT file',[('text file','.txt')],".txt"))
+            select_inputFilename_button=GUI_theme_util.create_button(window, width=GUI_IO_util.select_file_directory_button_width, text='Select INPUT TXT file', command=lambda: selectFile_set_options(window,True,False,inputFilename,input_main_dir_path,'Select INPUT TXT file',[('text file','.txt')],".txt"))
         elif config_input_output_numeric_options[0]==3: #single csv file:
             # buttons are set to normal or disabled in selectFile_set_options
-            select_inputFilename_button=tk.Button(window, width=GUI_IO_util.select_file_directory_button_width, text='Select INPUT csv file', command=lambda: selectFile_set_options(window,True,False,inputFilename,input_main_dir_path,'Select INPUT csv file',[('csv file','.csv')],".csv"))
+            select_inputFilename_button=GUI_theme_util.create_button(window, width=GUI_IO_util.select_file_directory_button_width, text='Select INPUT csv file', command=lambda: selectFile_set_options(window,True,False,inputFilename,input_main_dir_path,'Select INPUT csv file',[('csv file','.csv')],".csv"))
         if config_input_output_numeric_options[0]==4: #any type file (used in NLP.py)
             # buttons are set to normal or disabled in selectFile_set_options
-            select_inputFilename_button=tk.Button(window, width=GUI_IO_util.select_file_directory_button_width, text='Select INPUT file (any type)', command=lambda: selectFile_set_options(window,True,False,inputFilename,input_main_dir_path,'Select INPUT file (any file type: pdf, docx, html, txt, csv, conll); switch extension type below near File name:',[("txt file","*.txt"),("csv file","*.csv"),("pdf file","*.pdf"),("docx file","*.docx"),("rtf file","*.rtf"),("html file","*.html"),("CoNLL table","*.conll")], "*.*"))
+            select_inputFilename_button=GUI_theme_util.create_button(window, width=GUI_IO_util.select_file_directory_button_width, text='Select INPUT file (any type)', command=lambda: selectFile_set_options(window,True,False,inputFilename,input_main_dir_path,'Select INPUT file (any file type: pdf, docx, html, txt, csv, conll); switch extension type below near File name:',[("txt file","*.txt"),("csv file","*.csv"),("pdf file","*.pdf"),("docx file","*.docx"),("rtf file","*.rtf"),("html file","*.html"),("CoNLL table","*.conll")], "*.*"))
         if config_input_output_numeric_options[0]==5: #txt/html
             # buttons are set to normal or disabled in selectFile_set_options
-            select_inputFilename_button=tk.Button(window, width=GUI_IO_util.select_file_directory_button_width, text='Select INPUT file (txt, html)', command=lambda: selectFile_set_options(window,True,False,inputFilename,input_main_dir_path,'Select INPUT file (txt, html); switch extension type below near File name:',[("txt file","*.txt"),("html file","*.html")], "*.*"))
+            select_inputFilename_button=GUI_theme_util.create_button(window, width=GUI_IO_util.select_file_directory_button_width, text='Select INPUT file (txt, html)', command=lambda: selectFile_set_options(window,True,False,inputFilename,input_main_dir_path,'Select INPUT file (txt, html); switch extension type below near File name:',[("txt file","*.txt"),("html file","*.html")], "*.*"))
         if config_input_output_numeric_options[0]==6: #txt/csv
             # buttons are set to normal or disabled in selectFile_set_options
-            select_inputFilename_button=tk.Button(window, width=GUI_IO_util.select_file_directory_button_width, text='Select INPUT file (txt, csv)', command=lambda: selectFile_set_options(window,True,False,inputFilename,input_main_dir_path,'Select INPUT file (txt, csv); switch extension type below near File name:',[("txt file","*.txt"),("csv file","*.csv")], "*.*"))
+            select_inputFilename_button=GUI_theme_util.create_button(window, width=GUI_IO_util.select_file_directory_button_width, text='Select INPUT file (txt, csv)', command=lambda: selectFile_set_options(window,True,False,inputFilename,input_main_dir_path,'Select INPUT file (txt, csv); switch extension type below near File name:',[("txt file","*.txt"),("csv file","*.csv")], "*.*"))
 
         # place the Select INPUT file widget
         y_multiplier_integer = GUI_IO_util.placeWidget(window,GUI_IO_util.labels_x_coordinate,y_multiplier_integer,select_inputFilename_button,True)
 
         #setup a button to open Windows Explorer on the selected input file
-        openInputFile_button  = tk.Button(window, width=GUI_IO_util.open_file_directory_button_width, text='',
+        openInputFile_button  = GUI_theme_util.create_button(window, width=GUI_IO_util.open_file_directory_button_width, text='',
                             command=lambda: IO_files_util.open_file_removing_date_from_filename(window,inputFilename.get(),True))
         y_multiplier_integer = GUI_IO_util.placeWidget(window,
             GUI_IO_util.IO_configuration_menu, y_multiplier_integer,
@@ -976,13 +976,13 @@ def IO_config_setup_full (window, y_multiplier_integer):
     #primary INPUT directory ______________________________________________
     if config_input_output_numeric_options[1]==1: # main directory input
         # buttons are set to normal or disabled in selectFile_set_options
-        select_input_main_dir_button = tk.Button(window, width=GUI_IO_util.select_file_directory_button_width,
+        select_input_main_dir_button = GUI_theme_util.create_button(window, width=GUI_IO_util.select_file_directory_button_width,
             text='Select INPUT files directory',  command = lambda: selectDirectory_set_options(window,input_main_dir_path,output_dir_path,"Select INPUT files directory",True))
         # select_input_main_dir_button.config(state="normal")
         y_multiplier_integer = GUI_IO_util.placeWidget(window,GUI_IO_util.labels_x_coordinate,y_multiplier_integer,select_input_main_dir_button,True)
 
         #setup a button to open Windows Explorer on the selected main input directory
-        openDirectory_button  = tk.Button(window, width=GUI_IO_util.open_file_directory_button_width,
+        openDirectory_button  = GUI_theme_util.create_button(window, width=GUI_IO_util.open_file_directory_button_width,
                             text='', command=lambda: IO_files_util.open_directory_removing_date_from_directory(window,input_main_dir_path.get(),True))
         y_multiplier_integer = GUI_IO_util.placeWidget(window,
             GUI_IO_util.IO_configuration_menu,
@@ -1006,12 +1006,12 @@ def IO_config_setup_full (window, y_multiplier_integer):
     #secondary INPUT directory ______________________________________________
     if config_input_output_numeric_options[2]==1: #secondary directory input
         # buttons are set to normal or disabled in selectFile_set_options
-        select_input_secondary_dir_button = tk.Button(window, width=GUI_IO_util.select_file_directory_button_width, text='Select INPUT secondary directory',  command=lambda: selectDirectory_set_options(window,input_main_dir_path, input_secondary_dir_path,"Select INPUT secondary TXT directory"))
+        select_input_secondary_dir_button = GUI_theme_util.create_button(window, width=GUI_IO_util.select_file_directory_button_width, text='Select INPUT secondary directory',  command=lambda: selectDirectory_set_options(window,input_main_dir_path, input_secondary_dir_path,"Select INPUT secondary TXT directory"))
         y_multiplier_integer=GUI_IO_util.placeWidget(window,GUI_IO_util.labels_x_coordinate,
                             y_multiplier_integer,select_input_secondary_dir_button,True)
 
         #setup a button to open Windows Explorer on the selected secondary input directory
-        openDirectory_button  = tk.Button(window, width=GUI_IO_util.open_file_directory_button_width, text='', command=lambda: IO_files_util.openExplorer(window, input_secondary_dir_path.get()))
+        openDirectory_button  = GUI_theme_util.create_button(window, width=GUI_IO_util.open_file_directory_button_width, text='', command=lambda: IO_files_util.openExplorer(window, input_secondary_dir_path.get()))
         y_multiplier_integer = GUI_IO_util.placeWidget(window,
             GUI_IO_util.IO_configuration_menu,
             y_multiplier_integer,
@@ -1024,12 +1024,12 @@ def IO_config_setup_full (window, y_multiplier_integer):
     #OUTPUT directory ______________________________________________
     if config_input_output_numeric_options[3]==1: #output directory
         # buttons are set to normal or disabled in selectFile_set_options
-        select_output_dir_button = tk.Button(window, width=GUI_IO_util.select_file_directory_button_width, text='Select OUTPUT files directory',  command=lambda: selectDirectory_set_options(window,input_main_dir_path,output_dir_path,"Select OUTPUT files directory"))
+        select_output_dir_button = GUI_theme_util.create_button(window, width=GUI_IO_util.select_file_directory_button_width, text='Select OUTPUT files directory',  command=lambda: selectDirectory_set_options(window,input_main_dir_path,output_dir_path,"Select OUTPUT files directory"))
         y_multiplier_integer=GUI_IO_util.placeWidget(window,GUI_IO_util.labels_x_coordinate,y_multiplier_integer,select_output_dir_button,True)
 
         #setup a button to open Windows Explorer on the selected input directory
         # current_y_multiplier_integer4=y_multiplier_integer-1
-        openDirectory_button  = tk.Button(window, width=GUI_IO_util.open_file_directory_button_width, text='', command=lambda: IO_files_util.openExplorer(window, output_dir_path.get()))
+        openDirectory_button  = GUI_theme_util.create_button(window, width=GUI_IO_util.open_file_directory_button_width, text='', command=lambda: IO_files_util.openExplorer(window, output_dir_path.get()))
         y_multiplier_integer = GUI_IO_util.placeWidget(window,
             GUI_IO_util.IO_configuration_menu,
             y_multiplier_integer,
@@ -1574,7 +1574,7 @@ def GUI_bottom(config_filename, config_input_output_numeric_options, y_multiplie
     #         charts_package_options_widget.set('Plotly')
     # charts_package_options_widget.trace('w',warning_message)
 
-    readme_button = tk.Button(window, text='Read Me',command=readMe_command,width=10,height=2)
+    readme_button = GUI_theme_util.create_button(window, text='Read Me',command=readMe_command,width=10,height=2)
     # In NLP_setup_IO_main and NLP_setup_package_language_main an extra line of widgets is added to the GUI
     # if "NLP_setup_IO_main" in scriptName:
     #     y_multiplier_integer = y_multiplier_integer +1
@@ -1718,7 +1718,7 @@ def GUI_bottom(config_filename, config_input_output_numeric_options, y_multiplie
 
     # do not display CLOSE button for the 3 NLP_setup GUIs; the CLOSE is handled in those GUIs
     if not "NLP_setup_" in scriptName:
-        close_button = tk.Button(window, text='CLOSE', width=10,height=2, command=lambda: _close_window())
+        close_button = GUI_theme_util.create_button(window, text='CLOSE', width=10,height=2, command=lambda: _close_window())
         # place widget with hover-over info
         y_multiplier_integer = GUI_IO_util.placeWidget(window, GUI_IO_util.close_button_x_coordinate,
                                                        y_multiplier_integer,

--- a/src/GUI_util.py
+++ b/src/GUI_util.py
@@ -1169,7 +1169,9 @@ def display_about_release_team_cite_buttons(scriptName):
             y_multiplier_integer = 1.7
         else:
             y_multiplier_integer = 0
-        about_button = tk.Button(window, text='About', width=15, height=1, foreground="red",
+        # CTk migration (slice 2a): themed CTk buttons. foreground="red" is dropped -- the NLP Suite
+        # theme now paints these as red-filled buttons with light text (red-on-red otherwise).
+        about_button = GUI_theme_util.create_button(window, text='About', width=15, height=1,
                                 command=lambda: GUI_IO_util.about())
         # place widget with hover-over info
         y_multiplier_integer = GUI_IO_util.placeWidget(window,
@@ -1180,7 +1182,7 @@ def display_about_release_team_cite_buttons(scriptName):
                                                        GUI_IO_util.about_button_x_coordinate,
                                                        "Click on the button to access the About page of the NLP Suite GitHub repository.\nYou must be connected to the internet.")
 
-        release_history_button = tk.Button(window, text='Release history', width=15, height=1, foreground='red',
+        release_history_button = GUI_theme_util.create_button(window, text='Release history', width=15, height=1,
                                            command=lambda: GUI_IO_util.release_history())
         # place widget with hover-over info
         y_multiplier_integer = GUI_IO_util.placeWidget(window,
@@ -1191,7 +1193,7 @@ def display_about_release_team_cite_buttons(scriptName):
                                                        GUI_IO_util.about_button_x_coordinate,
                                                        "Click on the button to access the Release history page of the NLP Suite GitHub repository.\nYou must be connected to the internet.")
 
-        team_button = tk.Button(window, text='NLP Suite team', width=15, height=1, foreground="red",
+        team_button = GUI_theme_util.create_button(window, text='NLP Suite team', width=15, height=1,
                                 command=lambda: GUI_IO_util.list_team())
         # place widget with hover-over info
         y_multiplier_integer = GUI_IO_util.placeWidget(window,
@@ -1202,7 +1204,7 @@ def display_about_release_team_cite_buttons(scriptName):
                                                        GUI_IO_util.release_history_button_x_coordinate,
                                                        "Click on the button to access the Team page of the NLP Suite GitHub repository.\nYou must be connected to the internet.")
 
-        cite_button = tk.Button(window, text='How to cite', width=15, height=1, foreground="red",
+        cite_button = GUI_theme_util.create_button(window, text='How to cite', width=15, height=1,
                                 command=lambda: GUI_IO_util.cite_NLP())
         # place widget with hover-over info
         y_multiplier_integer = GUI_IO_util.placeWidget(window,

--- a/src/statistics_csv_main.py
+++ b/src/statistics_csv_main.py
@@ -12,6 +12,7 @@ import tkinter.messagebox as mb
 import tkinter.filedialog
 
 import GUI_IO_util
+import GUI_theme_util
 import IO_csv_util
 import IO_user_interface_util
 import IO_files_util
@@ -369,7 +370,7 @@ input_csv_file_button = tk.Button(window, width=GUI_IO_util.select_file_director
 y_multiplier_integer = GUI_IO_util.placeWidget(window, GUI_IO_util.labels_x_coordinate, y_multiplier_integer,
                                                input_csv_file_button, True)
 
-open_input_csv_file_button = tk.Button(window, width=GUI_IO_util.open_file_directory_button_width, text='',
+open_input_csv_file_button = GUI_theme_util.create_open_file_button(window,
                                        command=lambda: IO_files_util.openFile(window, input_csv_file_var.get()))
 y_multiplier_integer = GUI_IO_util.placeWidget(window, GUI_IO_util.IO_configuration_menu, y_multiplier_integer,
                                                open_input_csv_file_button,


### PR DESCRIPTION
Second slice of the CustomTkinter migration (see `docs/CustomTkinter-Migration-Plan.md`), stacked on the `GUI_theme_util` compat layer from #1641 (merged).

- **Slice 1 — root → `CTk()`**: `GUI_util`'s root window is now a real `customtkinter.CTk()` (appearance pinned `light`). Verified: `NLP_menu_main` builds and runs; full GUI smoke suite green.
- **Slice 2a — theme the shared chrome, keep `.place` layout**: all window-parented buttons (RUN/CLOSE/Read Me/About-row/`?HELP` column/I-O buttons), the shared chrome `OptionMenu`s (setup, chart/data, videos/tips/reminders), and the open-output checkbox now go through the `GUI_theme_util` CTk factories (`create_button`/`create_option_menu`/`create_checkbox`). `hover_over_widget` was made CTk-safe (tooltip-only hover path for CTk widgets; the legacy tk hover path is byte-for-byte unchanged). Pixel layout (`.place`) is untouched — zero reflow risk, so this slice is a pure widget-class swap.

Dropped 6 `.configure(foreground="red")` calls on menus in the process — `CTk` `OptionMenu` has no `foreground` kwarg and the theme is already solid red, so the red/black availability cue on those menus is deferred polish (tracked, not lost).

Verified by launching `NLP_menu_main` and the standard tool GUIs; screenshots of the themed chrome available on request.

Grid reflow (slice 2b) and the remaining popups (slice 3) are separate, independently-reviewable follow-on slices stacked on this branch.