### PR TITLE
Fix CTk compat layer: char/line->px must not guess "already pixels" by size

### DIFF
--- a/src/GUI_theme_util.py
+++ b/src/GUI_theme_util.py
@@ -45,9 +45,6 @@ _PX_PER_CHAR = 8
 _PX_PER_LINE = 22
 # A CTk widget's natural (default) height, used as the floor when translating small line counts.
 _MIN_WIDGET_PX = 28
-# Above this, an incoming height/width is assumed to already be pixels (a CTk-aware caller), not
-# a legacy line/character count, so it is passed through unchanged.
-_ALREADY_PX_THRESHOLD = 60
 
 # tk keyword -> CTk keyword renames. (Colors: tk ``foreground``/``fg`` -> CTk ``text_color``.)
 _RENAME = {
@@ -92,6 +89,12 @@ _DROP = frozenset(
 def char_width_to_px(char_width, px_per_char=_PX_PER_CHAR, padding=0):
     """Translate a legacy tk character-based width into a CTk pixel width.
 
+    The input is *always* treated as a character count -- there is no magnitude cutoff that guesses
+    "this looks big, it must already be pixels". Legacy char widths in the suite run past 200 (wide
+    file-path and search entries), so any such guess would shrink exactly the widest fields. A caller
+    that genuinely holds a pixel width bypasses this multiply via ``width_is_chars=False`` in
+    :func:`translate_kwargs` (see :func:`create_slider`) instead.
+
     Returns ``None`` for a missing / non-positive / non-numeric width so the caller can drop the
     ``width`` kwarg entirely and let CTk use its own default sizing.
     """
@@ -101,13 +104,15 @@ def char_width_to_px(char_width, px_per_char=_PX_PER_CHAR, padding=0):
         return None
     if n <= 0:
         return None
-    if n > _ALREADY_PX_THRESHOLD:
-        return n  # already pixels (CTk-aware caller)
     return n * px_per_char + padding
 
 
 def line_height_to_px(char_height):
     """Translate a legacy tk line-based height (e.g. a 2-line RUN button) into a CTk pixel height.
+
+    Like :func:`char_width_to_px`, the input is always treated as a line count -- pixel-holding
+    callers use ``height_is_lines=False`` in :func:`translate_kwargs` (as :func:`create_entry` does)
+    rather than relying on a magnitude guess.
 
     Returns ``None`` for a missing / non-positive / non-numeric height so the caller drops the
     ``height`` kwarg and CTk uses its default widget height.
@@ -118,8 +123,6 @@ def line_height_to_px(char_height):
         return None
     if n <= 0:
         return None
-    if n > _ALREADY_PX_THRESHOLD:
-        return n  # already pixels
     return max(_MIN_WIDGET_PX, n * _PX_PER_LINE)
 
 

--- a/tests/test_gui_theme_util.py
+++ b/tests/test_gui_theme_util.py
@@ -27,9 +27,11 @@ class TestCharWidthToPx:
     def test_missing_or_nonpositive_returns_none(self, bad):
         assert gtu.char_width_to_px(bad) is None
 
-    def test_large_value_treated_as_already_pixels(self):
-        # A CTk-aware caller passing a real pixel width must not be multiplied again.
-        assert gtu.char_width_to_px(300) == 300
+    def test_large_char_width_still_multiplied(self):
+        # No magnitude cutoff: a wide legacy entry (e.g. a 115-char file-path field) must be scaled
+        # to pixels like any other char width, not passed through as ~115px. Pixel-holding callers
+        # opt out via width_is_chars=False in translate_kwargs, not via a magic size threshold.
+        assert gtu.char_width_to_px(115) == 115 * gtu._PX_PER_CHAR
 
     def test_numeric_string_is_accepted(self):
         assert gtu.char_width_to_px("12") == 12 * gtu._PX_PER_CHAR
@@ -47,8 +49,10 @@ class TestLineHeightToPx:
     def test_missing_or_nonpositive_returns_none(self, bad):
         assert gtu.line_height_to_px(bad) is None
 
-    def test_large_value_treated_as_already_pixels(self):
-        assert gtu.line_height_to_px(440) == 440
+    def test_large_line_count_still_multiplied(self):
+        # Same rule as width: no magnitude cutoff. Pixel-holding heights bypass via
+        # height_is_lines=False (see test_entry_height_not_line_translated_when_flag_off).
+        assert gtu.line_height_to_px(20) == max(gtu._MIN_WIDGET_PX, 20 * gtu._PX_PER_LINE)
 
 
 # ── translate_kwargs (against real CTk 6.0.0 signatures) ─────────────────────
@@ -69,6 +73,12 @@ class TestTranslateKwargs:
         # create_entry passes height_is_lines=False; a raw pixel height must survive unchanged.
         out = gtu.translate_kwargs(ctk.CTkEntry, {"height": 40}, height_is_lines=False)
         assert out["height"] == 40
+
+    def test_width_not_char_translated_when_flag_off(self):
+        # The pixel escape hatch: a CTk-aware caller passes width_is_chars=False and its raw pixel
+        # width must survive unmultiplied (this replaces the old magnitude-guess passthrough).
+        out = gtu.translate_kwargs(ctk.CTkEntry, {"width": 920}, width_is_chars=False)
+        assert out["width"] == 920
 
     def test_zero_width_is_dropped_not_zeroed(self):
         # width<=0 -> None -> drop, so CTk keeps its own default sizing rather than a 0px widget.


### PR DESCRIPTION
## Problem

`GUI_theme_util.char_width_to_px` / `line_height_to_px` (the CTk migration compat layer) treat any value above `_ALREADY_PX_THRESHOLD = 60` as a width/height that is *already in pixels* and pass it through unmultiplied:

```python
if n > _ALREADY_PX_THRESHOLD:
    return n  # already pixels (CTk-aware caller)
```

But legacy tk **character** widths in the suite routinely exceed 60 — and they're the widest, most important fields:

| Call site | Widget | `width=` (chars) |
|---|---|---|
| `csv_file_entry` | `tk.Entry` (CSV file path) | **115** |
| `selectedCsvFile` | `tk.Entry` (disabled path) | **110** |
| search box | `tk.Entry` | **200** |
| `operation_results_text` | `tk.Text` | **100** |

Once the compat layer is wired onto `GUI_util`, `char_width_to_px(115)` returns `115` px instead of `115 * 8 = 920` px — the field renders at roughly **1/8** its intended width. Every character width in the 61–300 band is affected.

It's currently latent (nothing imports the module yet), but it's new in-scope code that will misfire on real call sites the moment Phase 1 wiring lands.

## Why remove the threshold rather than raise it

There's no safe number: real char widths reach 200+ while plausible pixel widths start ~100 and windows hit 800–1100, so the two ranges **overlap** — any cutoff mis-sizes something.

The correct disambiguation already exists and is already used: the explicit `width_is_chars` / `height_is_lines` flags on `translate_kwargs` (`create_slider` passes `width_is_chars=False`; `create_entry` passes `height_is_lines=False`). This change removes the magnitude guess and makes those flags the sole char-vs-pixel signal. A CTk-aware caller holding real pixels passes `width_is_chars=False`.

## Tests

- Replaced the two unit tests that encoded the old passthrough (`char_width_to_px(300) == 300`, `line_height_to_px(440) == 440`) with ones asserting a large char/line count still multiplies.
- Added `test_width_not_char_translated_when_flag_off` covering the `width_is_chars=False` escape hatch (the width analog of the existing height-flag test).

`pytest tests/test_gui_theme_util.py` → 30 passed. Ruff clean.