### PR TITLE
Fix gui_smoke.py to stub customtkinter instead of patching fake tkinter

### DIFF
--- a/tests/gui_smoke.py
+++ b/tests/gui_smoke.py
@@ -145,7 +145,18 @@ _STUB_ROOTS = {'stanza','spacy','nltk','torch','torchvision','transformers','sen
                'transformer_srl','wikipedia','newspaper','tweepy','praw','umap','hdbscan','bertopic',
                'spacy_langdetect','spacytextblob','contractions','unidecode','chardet','pdfplumber',
                'docx','fitz','striprtf','pyLDAvis','little_mallet_wrapper','tkcolorpicker','tkinterdnd2',
-               'pymupdf','pdf2image','pytesseract','wikipediaapi','geotext','reverse_geocoder'}
+               'pymupdf','pdf2image','pytesseract','wikipediaapi','geotext','reverse_geocoder',
+               'customtkinter'}
+# customtkinter (CTk migration, GUI_theme_util) can't be handled like the fake-tkinter widgets above:
+# its real widget classes subclass real tkinter.Frame/tkinter.Tk AT IMPORT TIME (e.g. CTkBaseClass(
+# tkinter.Frame, ...)), which the fake tkinter's `_rec` function stand-ins can't satisfy (you can't
+# subclass a function), and constructing a real CTk widget needs a live Tk root/mainloop this headless
+# harness deliberately doesn't have. Stubbing it as a MagicMock tree -- like the other heavy libs --
+# sidesteps that: GUI_theme_util.translate_kwargs()'s `inspect.signature(cls.__init__)` introspection
+# resolves against Mock.__init__ (yielding an empty/harmless accepted-params set) and construction
+# calls just return a fresh MagicMock, so import and use of GUI_theme_util succeeds without ever
+# building a real widget. The GOLDEN-checked labels (DB_SQL, corpus_profiler) are built with plain
+# tk.Button/tk.Checkbutton, not GUI_theme_util factories, so they're unaffected and still recorded.
 
 
 class _StubLoader(importlib.abc.Loader):


### PR DESCRIPTION
## Summary
- The CTk migration's `GUI_theme_util` (`import customtkinter as ctk`) is now in the import chain of most `src/*_main.py` GUIs via `GUI_IO_util.place_help_button`'s "? HELP" button.
- `tests/gui_smoke.py`'s harness stubs `tkinter` with plain recorder functions in place of `Tk`/`Frame`/`Canvas`/etc. Real CustomTkinter subclasses those at import time (`class CTkBaseClass(tkinter.Frame, ...)`), so `import customtkinter` crashed under the fake tkinter with `ImportError: cannot import name 'Variable' from 'tkinter'` — and even with `Variable` added, subclassing a stub function instead of a real class would still crash, and real CTk widgets need a live Tk root/mainloop this headless harness deliberately doesn't have. That masked real construction-crash signal for every GUI reaching `GUI_theme_util`.
- Fix: stub `customtkinter` itself as a `MagicMock` tree via the existing `_STUB_ROOTS` mechanism (same pattern already used for other heavy libs like `torch`/`spacy`). Verified `GUI_theme_util`'s `inspect.signature`-based kwarg translation and widget-construction wrappers tolerate the mock without crashing. The GOLDEN-checked widget labels (`DB_SQL_main.py`, `corpus_profiler_main.py`) are built with plain `tk.Button`/`tk.Checkbutton`, not `GUI_theme_util` factories, so they're unaffected and still captured.

## Test plan
- [x] `python tests/gui_smoke.py` — the customtkinter `ImportError` crashes are gone; 44/54 OK, 0 missing golden, remaining 5 crashes are pre-existing env gaps unrelated to this fix (`spellchecker`, `pdfminer` not installed in the base env), 5 known-skip.
- [x] `pytest tests/` — 32 passed.