### PR TITLE
CTk migration Phase 1 slice 2b: placeWidget -> grid reflow + NLP_menu polish

### DIFF
--- a/NLP_Suite.spec
+++ b/NLP_Suite.spec
@@ -168,6 +168,9 @@ _third_party_hiddenimports = [
     'chardet', 'tqdm', 'psutil', 'json', 'csv', 'pickle',
     'collections', 'functools', 'itertools', 'statistics',
     'SPARQLWrapper',
+    # CustomTkinter GUI reskin (CTk migration). darkdetect is CTk's appearance-mode dep and is
+    # imported conditionally inside CTk, so PyInstaller needs it listed explicitly.
+    'customtkinter', 'darkdetect',
 ]
 
 # Collect stanza and spacy data files (language models etc.)
@@ -181,6 +184,12 @@ try:
 except Exception:
     _spacy_datas = []
 _nltk_datas = []  # nltk downloads data at runtime
+# CustomTkinter ships its own bundled color themes / assets that it loads at runtime
+# (set_default_color_theme, widget drawing); collect them so the reskin renders in the bundle.
+try:
+    _ctk_datas = collect_data_files('customtkinter')
+except Exception:
+    _ctk_datas = []
 
 # ── Data files to bundle ────────────────────────────────────────────────────
 # These are copied alongside the executable so the app can find them at runtime.
@@ -210,8 +219,11 @@ def _collect_tree(src_dir, dest_prefix):
 _project_datas = []
 
 # All src/*.py files (needed because GUIs check for .py files and some launch via subprocess).
+# Also ship the CustomTkinter theme JSON (CTk migration): GUI_theme_util.init_appearance() loads
+# it from <exe>/src via GUI_IO_util.scriptPath, so it must sit alongside the .py files, not in
+# _internal (the .py-only filter would otherwise drop it).
 for f in os.listdir(SRC_DIR):
-    if f.endswith('.py') and not f.startswith('_'):
+    if (f.endswith('.py') or f == 'nlp_suite_theme.json') and not f.startswith('_'):
         _project_datas.append((os.path.join(SRC_DIR, f), 'src'))
 
 # Library data (recursive)
@@ -244,7 +256,7 @@ a = Analysis(
     [os.path.join(SRC_DIR, 'NLP_menu_main.py')],
     pathex=[SRC_DIR],
     binaries=[],
-    datas=_project_datas + _stanza_datas + _spacy_datas + _nltk_datas,
+    datas=_project_datas + _stanza_datas + _spacy_datas + _nltk_datas + _ctk_datas,
     hiddenimports=_local_modules + _third_party_hiddenimports,
     hookspath=[],
     hooksconfig={},

--- a/docs/CustomTkinter-Migration-Plan.md
+++ b/docs/CustomTkinter-Migration-Plan.md
@@ -13,6 +13,33 @@ testing checklist.
 
 ---
 
+## 0. Design premise: color is a signal, not styling (read first)
+
+> **Reviewer redirect (Roberto, 2026-07).** The first cut of the theme painted *every* widget in
+> the brand red `#b10a0a`. That shipped briefly and was reverted: the solid-red theme made GUIs
+> read as noise, and — more fundamentally — it **overwrote a load-bearing convention**. In the NLP
+> Suite, **red already means something**: a red *Open TIPS* / *Watch videos* / *Open reminders*
+> dropdown signals that that resource *exists for this GUI*; grey means none is available (the
+> in-app tooltips literally promise "when TIPS are available the widget is red, otherwise black").
+> A blanket-red theme erases that signal, and no amount of layout polish restores it — it's the
+> premise, not the finish.
+
+So the accent is **reserved for meaning**. The rule for the whole migration:
+
+- **Neutral / muted by default.** Ordinary controls — the majority of buttons, checkboxes, option
+  menus, comboboxes — are a neutral grey. They carry no special meaning, so they get no accent.
+- **Red only where it carries information.** Exactly two things earn the brand red:
+  1. the **availability signal** on the *TIPS / videos / reminders* dropdowns (red = available for
+     this GUI, grey = none), and
+  2. the single **RUN** primary-action button per GUI (the one "do the thing" affordance).
+
+This is a *redirect, not a rejection* of the grid work: the grid engine (§2.2) stands, and the
+incremental path below is exactly right once the theme honors this premise. The theme-JSON default
+colors and the `accent=`/`muted=` opt-ins in `GUI_theme_util` are what encode it — see the widget
+mapping (§3) and the Phase 1 accent-signal slice note (§4).
+
+---
+
 ## 1. Current state (audit)
 
 Numbers below were measured on `current-stable` (July 2026).
@@ -99,8 +126,11 @@ CTk layout is months of work and guarantees regressions. Instead:
 Concretely, we introduce one new shared module, **`src/GUI_theme_util.py`** (name open to
 debate), that:
 
-1. Owns `customtkinter` setup: appearance mode, the NLP Suite theme (accent red `#b10a0a`,
-   the suite's brand color per the note at `GUI_util.py:188-190`), and widget-scaling defaults.
+1. Owns `customtkinter` setup: appearance mode, the NLP Suite theme, and widget-scaling defaults.
+   The theme is **neutral grey by default**; the brand red `#b10a0a` (the color at
+   `GUI_util.py:188-190`) is an *opt-in accent*, applied only to the two things that carry meaning
+   (§0): the availability-signal dropdowns and the RUN button. It is **never** the default fill for
+   ordinary widgets — that was the reverted first cut.
 2. Exposes thin factory wrappers so GUI scripts stop calling `tk.Button(...)` directly:
    `create_button`, `create_checkbox`, `create_label`, `create_entry`, `create_option_menu`,
    `create_combobox`, `create_slider`, `create_textbox`. Each wrapper accepts the *old tk-style
@@ -207,7 +237,8 @@ can coexist under a `CTk` root during the transition.
   The per-OS `requirements-mac.txt` / `requirements-windows.txt` are installed *in addition* to the
   base file, so the pin goes in `requirements.txt` **only** (adding it to all three would just
   double-install).
-- Add `nlp_suite_theme.json` (CTk color theme: accent `#b10a0a`, neutral grays) under `src/` so
+- Add `nlp_suite_theme.json` (CTk color theme: **neutral grays as the default fill**; brand red
+  `#b10a0a` reserved as an opt-in accent per §0, not painted on every widget) under `src/` so
   PyInstaller ships it (the spec's `src` collection is `.py`-only, so it needs an explicit datas
   entry — done).
 - PyInstaller: add `collect_data_files('customtkinter')` to `NLP_Suite.spec` datas and
@@ -278,6 +309,24 @@ can coexist under a `CTk` root during the transition.
 > (unfinished; only call site is commented out). Both carry an in-code marker noting the deferral.
 > Still outstanding: on-screen QA of the converted modals on Mac + Windows (they can't be visually
 > verified headlessly).
+>
+> **Accent-signal slice (2026-07-17)** — implements the §0 redirect after the solid-red theme was
+> reverted. Stacked fork branch `ctk/phase1-accent-signal` (base `ctk/phase1-popups`). Three moves:
+> (1) `nlp_suite_theme.json` — every interactive widget's default fill flipped from brand red to a
+> neutral grey (`CTkButton`, `CTkCheckBox`, `CTkOptionMenu`, `CTkComboBox`, `CTkRadioButton`,
+> `CTkSlider`, `CTkSwitch`, `CTkProgressBar`, `CTkSegmentedButton`, and the `DropdownMenu` hover);
+> entries/textboxes/frames were already neutral and are untouched. (2) `GUI_theme_util` — added an
+> `accent=True` opt-in to `create_button` and `create_option_menu` that paints the brand red
+> (`create_option_menu` already had `muted=True` for the "nothing available" grey; `accent` is its
+> complement for the "available" red). (3) `GUI_util` — the **RUN** button and the *available*
+> branches of the TIPS / videos / reminders dropdowns now pass `accent=True`; their *unavailable*
+> branches keep `muted=True`. Net effect: neutral grey everywhere, red only on RUN and on a dropdown
+> that actually has a resource — the availability cue is restored and the "wall of red" is gone.
+> Verified: `tests/gui_smoke.py` and `pytest` green (theme is data + kwarg plumbing, no golden/label
+> change). **Still outstanding:** on-screen QA on Mac + Windows to confirm the grey reads as
+> actionable (not disabled) and the red reads as signal; and a call whether RUN should keep the red
+> accent or go neutral like the rest (left red here as the single primary-action affordance — a
+> one-line flip if Roberto prefers otherwise).
 
 After Phase 1, **every GUI already looks substantially better** (new chrome, themed top/bottom
 bars, help column, scrollable body) even though its own widgets are still plain tk.

--- a/docs/CustomTkinter-Migration-Plan.md
+++ b/docs/CustomTkinter-Migration-Plan.md
@@ -232,6 +232,26 @@ can coexist under a `CTk` root during the transition.
    `place_help_button`; `message_box_widget`, `enter_value_widget`, `slider_widget`,
    `dropdown_menu_widget*`, `combobox_with_search_widget` popups → CTkToplevel + wrappers.
 
+> **Status (2026-07):** PR 1 (`GUI_theme_util` compat layer + Phase 0 groundwork) merged to
+> `roberto` as **PR #1641**. PR 2 (root → `CTk()`, shared-chrome factory conversions, `GUI_top`
+> intro widget, kept the `.place()` layout — "slice 2a") lives on `ctk/phase1-core`, opened
+> against `roberto` as **PR #1645** now that PR 1 has landed there. It includes the
+> folder-icon open-button fix (the "open selected file/directory" buttons were rendering as
+> empty ~8px slivers — `width=1, text=''` — fixed via a new `GUI_theme_util.create_open_file_button`
+> themed `CTkButton`) and the logo-column tightening (logo 85×50 → 58×34, column-0 minsize
+> 210 → 122), moved here from the grid-reflow branch since both are chrome/theming fixes
+> independent of the grid engine itself.
+>
+> `placeWidget` → `grid()` ("slice 2b") lives on `ctk/phase1-grid`, stacked on `ctk/phase1-core`
+> as **fork PR #3**. First render is clean on `statistics_csv_main` and the suite is green, but
+> it's still WIP — open punch-list items: window geometry is tuned to the old absolute layout
+> (~35% empty on the right); `IO_config_setup_brief()` creates a duplicate INPUT display box
+> (two ~450px boxes render side by side, a major overflow driver, flagged with a
+> `TODO(ctk-migration)`); `NLP_menu_main`'s `ttk.Notebook` is still `.place()`d over the gridded
+> chrome and needs special-casing; multi-column GUIs (SVO, GIS) and the raw-`.place()` GUIs
+> (`data_visualization_main.py`, 140 sites) are unvalidated; and the per-GUI click-test list
+> (widest/busiest rows, the `sameY` path, notebook GUIs, baseline sanity) is still outstanding.
+
 After Phase 1, **every GUI already looks substantially better** (new chrome, themed top/bottom
 bars, help column, scrollable body) even though its own widgets are still plain tk.
 

--- a/docs/CustomTkinter-Migration-Plan.md
+++ b/docs/CustomTkinter-Migration-Plan.md
@@ -343,6 +343,34 @@ Prove the mechanical conversion recipe end-to-end and refine the wrappers:
 Write down every deviation the pilots force into the per-file checklist (§6) before mass
 conversion.
 
+> **Status (2026-07-18) — pilot 1 `wordclouds_main.py`: done** (branch `ctk/phase2-wordclouds`).
+> 29 constructors → factories, 3 `OptionMenu` → `create_option_menu(values=[...])`, the open-image
+> sliver → `create_open_file_button`, `ttk.Style`/`theme_use` dropped, dynamic csv-field
+> repopulation → `set_values`. Launched and screenshotted on macOS: neutral greys with red only on
+> RUN and the *available* TIPS / videos / reminders dropdowns, exactly the §0 premise.
+>
+> **Three legacy idioms CTk does not support** turned up, all of which recur suite-wide and are now
+> checklist items in §6: `.config(` (raises; 53 sites in this one file), `widget['state']` (raises),
+> and `widget['values'] = …` (**silently no-ops** — the nastiest, and *not* caught by the `["menu"]`
+> grep). Assume every Phase 3 file has all three.
+>
+> **Two shared-layer fixes the pilot forced:**
+> 1. `GUI_theme_util.create_entry` now adds a 14 px chrome allowance to the char→px width
+>    translation (new `width_padding` arg on `translate_kwargs`). CTkEntry reserves internal padding
+>    around its text area, so small entries lost ~2 cells — the 4-char "Max no. of words" box
+>    rendered `100` as `10C`. This is the §5.2 tail arriving; expect more of it.
+> 2. `tests/gui_smoke.py` stubbed `customtkinter` as a **blanket MagicMock**, which answers every
+>    call and subscript and therefore absorbed *all three* idiom bugs silently (wordclouds passed a
+>    smoke run while broken, recording **0 widgets**). Replaced with a hand-written stub that
+>    reproduces the three real CTk contracts and records `text=`. Without this the smoke suite would
+>    have gone progressively blind exactly as Phase 3 converts the other ~45 GUIs — **this fix is a
+>    prerequisite for trusting the batch phase**, not a nicety. The contracts it emulates are pinned
+>    against real CTk in `tests/test_gui_theme_util.py` so a CTk upgrade can't drift them apart.
+>
+> Still outstanding for pilot 1: Windows QA, and the deferred #1648 window-geometry item (the window
+> is still sized to the old absolute layout, so the rightmost column clips) — not introduced here.
+> Pilots 2 (`NLP_menu_main.py`) and 3 (`NLP_setup_IO_main.py`) not yet started.
+
 ### Phase 3 — Batch conversion (~6–8 PRs, 5–8 GUIs each)
 
 Mechanical per-file recipe (greppable, reviewable):
@@ -460,6 +488,17 @@ For each `*_main.py` PR:
 - [ ] All `tk.`/`ttk.` widget constructors replaced with `GUI_theme_util` factories
       (grep: `tk.Button(`, `tk.Checkbutton(`, `tk.Label(`, `tk.Entry(`, `tk.OptionMenu(`,
       `ttk.Combobox(`, `tk.Scale(`, `tk.Text(`).
+- [ ] **No `.config(` left** (grep `\.config\(` → `.configure(`). CTk implements `config()` *only to
+      raise* `AttributeError`. This is the single highest-volume edit in a conversion — 53 sites in
+      the first pilot alone.
+- [ ] **No `widget['option']` reads left** (grep `\w\['`) — e.g. `menu['state']`. CTk resolves
+      `__getitem__` against the underlying tk frame, which has no such option → `TclError`.
+      Use `widget.cget('option')`.
+- [ ] **No `widget['values'] = …` / `widget[k] = v` writes left.** The dangerous one: tkinter's
+      `__setitem__` calls `configure({k: v})`, which lands the dict on CTk's **first positional
+      parameter `require_redraw`** — so it *silently does nothing*, no exception. Use
+      `GUI_theme_util.set_values(...)` / `widget.configure(k=v)`. **The `["menu"]` grep below does
+      not catch this** (it is the `ttk.Combobox` analogue).
 - [ ] No `["menu"]` OptionMenu manipulation left (grep `["menu"]`).
 - [ ] No `ttk.Style`/`theme_use` left.
 - [ ] No new `CTkImage`/`ImageTk` usage (grep).

--- a/docs/CustomTkinter-Migration-Plan.md
+++ b/docs/CustomTkinter-Migration-Plan.md
@@ -260,6 +260,24 @@ can coexist under a `CTk` root during the transition.
 > are unvalidated against the column bucketing (Phase 4); the now-dead `hover_over_widget` machinery
 > is left for Phase 5 cleanup; and full per-GUI visual QA on Mac + Windows, light + dark, is still
 > outstanding.
+>
+> **Slice 3 (2026-07-17)** — the popup dialogs of Phase-1 item 3 → `CTkToplevel` + `GUI_theme_util`
+> wrappers. Stacked fork PR `coralynnkc/NLP-Suite` (`ctk/phase1-popups`, base `ctk/phase1-grid`).
+> **Converted (4 of the 5):** `slider_widget` (CTkSlider + a value label since CTkSlider has no built-in
+> readout; pinned to integer steps and returns an `int`, matching `tk.Scale`'s default resolution=1 and
+> every caller's integer use), `dropdown_menu_widget` and `dropdown_menu_widget2` (CTkToplevel +
+> `create_combobox`/`create_button`; dropped the dead `pack()`-then-`grid()` and moved OK out of the
+> combobox's grid cell — the two overlapped, invisible with translucent tk widgets, broken with opaque
+> CTk ones), and `enter_value_widget` (was a second bare `tk.Tk()` + its own `mainloop()`; now a
+> CTkToplevel parented to `GUI_util.window`, driven by `wait_window()`). Verified: a headless
+> construction smoke fires each popup's OK path and checks return values/types; `tests/gui_smoke.py`
+> (44 ok, 0 missing golden — unchanged) and `pytest` (33 passed) show no regression.
+> **Deliberately deferred to Phase 4 (as §4 already lists them):** `message_box_widget` (its OK/Yes/No
+> buttons + countdown labels are `.place()`d at pixel offsets computed from the packed `tk.Message`'s
+> height, and it fires on every RUN — the geometry needs on-screen QA) and `combobox_with_search_widget`
+> (unfinished; only call site is commented out). Both carry an in-code marker noting the deferral.
+> Still outstanding: on-screen QA of the converted modals on Mac + Windows (they can't be visually
+> verified headlessly).
 
 After Phase 1, **every GUI already looks substantially better** (new chrome, themed top/bottom
 bars, help column, scrollable body) even though its own widgets are still plain tk.

--- a/docs/CustomTkinter-Migration-Plan.md
+++ b/docs/CustomTkinter-Migration-Plan.md
@@ -242,15 +242,24 @@ can coexist under a `CTk` root during the transition.
 > 210 → 122), moved here from the grid-reflow branch since both are chrome/theming fixes
 > independent of the grid engine itself.
 >
-> `placeWidget` → `grid()` ("slice 2b") lives on `ctk/phase1-grid`, stacked on `ctk/phase1-core`
-> as **fork PR #3**. First render is clean on `statistics_csv_main` and the suite is green, but
-> it's still WIP — open punch-list items: window geometry is tuned to the old absolute layout
-> (~35% empty on the right); `IO_config_setup_brief()` creates a duplicate INPUT display box
-> (two ~450px boxes render side by side, a major overflow driver, flagged with a
-> `TODO(ctk-migration)`); `NLP_menu_main`'s `ttk.Notebook` is still `.place()`d over the gridded
-> chrome and needs special-casing; multi-column GUIs (SVO, GIS) and the raw-`.place()` GUIs
-> (`data_visualization_main.py`, 140 sites) are unvalidated; and the per-GUI click-test list
-> (widest/busiest rows, the `sameY` path, notebook GUIs, baseline sanity) is still outstanding.
+> `placeWidget` → `grid()` ("slice 2b") landed as **PR #1648** (`ctk/phase1-grid`) — **done**.
+> `placeWidget` grids widgets (x-coordinate → coarse semantic column band, row counter → grid row);
+> tooltips bind `GUI_theme_util.ToolTip`; `GUI_top`'s intro is gridded in the header row. It also
+> closed out the reflow artifacts on the front-door GUI: `NLP_menu_main`'s `ttk.Notebook` is gridded
+> (was floating over the chrome) with full-width dropdowns and trimmed height; the SETUP rows group
+> each checkbox with its wide button (the coarse grid otherwise stranded the checkbox and overflowed
+> the window); the blank open-config buttons got a folder glyph; the Courier monospace on the SETUP /
+> info buttons and notebook tabs became the native system UI font; and the top nav buttons
+> (About/Release history/team/cite, in `GUI_util`) moved to a 2×2 `place()`d block in the top-right
+> corner so they stop being pushed off the right edge by the wide buttons. The earlier
+> `IO_config_setup_brief()` duplicate-INPUT-box overflow driver was also fixed on this branch.
+>
+> **Out of scope for #1648 (deferred follow-ups, not blockers):** window geometry is still tuned to
+> the old absolute layout (~35% empty on the right on some GUIs — revisit `set_window` sizing);
+> multi-column GUIs (SVO, GIS) and the raw-`.place()` GUIs (`data_visualization_main.py`, 140 sites)
+> are unvalidated against the column bucketing (Phase 4); the now-dead `hover_over_widget` machinery
+> is left for Phase 5 cleanup; and full per-GUI visual QA on Mac + Windows, light + dark, is still
+> outstanding.
 
 After Phase 1, **every GUI already looks substantially better** (new chrome, themed top/bottom
 bars, help column, scrollable body) even though its own widgets are still plain tk.

--- a/requirements.txt
+++ b/requirements.txt
@@ -106,6 +106,12 @@ SPARQLWrapper
 
 # GUI
 tkcolorpicker
+# CustomTkinter GUI reskin (CTk migration -- docs/CustomTkinter-Migration-Plan.md). Pinned to the
+# version validated by the Phase 0 bundle smoke test (tests/ctk_bundle_smoke.py) under the portable
+# python-build-standalone interpreter; darkdetect is CTk's only hard runtime dep (pulled in
+# transitively). CTk 6.0.0 is compatible with the Pillow==10.4.0 pin above. Base-file only: the
+# per-OS requirements-mac/-windows files are installed *in addition* to this one.
+customtkinter==6.0.0
 
 # Auto-update via git
 pygit2

--- a/src/DB_PCACE_data_analysis_main.py
+++ b/src/DB_PCACE_data_analysis_main.py
@@ -1260,7 +1260,10 @@ y_multiplier_integer = GUI_IO_util.placeWidget(window,GUI_IO_util.open_reminders
                                    True, False, True, False, 90, GUI_IO_util.labels_x_indented_coordinate+300,
                                    "Use the dropdown menu to select the simplex data type value (e.g., police) for which you want to find simplex & complex objects usage.")
 
-value_parent_object_checkbox = tk.Checkbutton(window, text='Get simplex/complex objects of selected data type (& value)', variable=value_parent_object_var, onvalue=1, offvalue=0)
+# wraplength: this label is the widest widget in the far-right grid band; left as one line it ran
+# past the window's right edge (grid never auto-shrinks a Checkbutton). Wrapping to ~two lines keeps
+# the full text on-screen without touching the layout.
+value_parent_object_checkbox = tk.Checkbutton(window, text='Get simplex/complex objects of selected data type (& value)', variable=value_parent_object_var, onvalue=1, offvalue=0, wraplength=230, justify='left')
 # place widget with hover-over info
 y_multiplier_integer = GUI_IO_util.placeWidget(window,GUI_IO_util.open_setup_x_coordinate+150, y_multiplier_integer,
                                    value_parent_object_checkbox,

--- a/src/GUI_IO_util.py
+++ b/src/GUI_IO_util.py
@@ -404,22 +404,53 @@ def hover_over_widget(window, x_coordinate, y_coordinate, widget_name, no_hover_
 
 # when a widget has hover-over effects, the parameter no_hover_over_widget is set to False
 # widget_name is the name of the widget that needs to be placed in any of the GUI scripts as defined by tk.
+# CTk migration slice 2b: the legacy per-GUI absolute x-coordinate constants cluster into a handful
+# of left-to-right bands. Bucketing an x-value against these thresholds preserves the horizontal
+# ORDER of widgets on a row while dropping the exact pixel spacing (that is the point of the reflow:
+# grid columns are content-sized). Works for both the darwin and Windows constant blocks since their
+# magnitudes are comparable.
+_GRID_COLUMN_THRESHOLDS = (110, 250, 400, 560, 720, 900, 1020, 1120)
+# Top grid rows reserved for the header (intro text + logo); placeWidget content starts below.
+_GRID_HEADER_ROWS = 1
+
+
+def _x_to_column(x_coordinate):
+    """Map a legacy absolute x-coordinate to a semantic grid column index (0 = leftmost)."""
+    try:
+        x = float(x_coordinate)
+    except (TypeError, ValueError):
+        return 1
+    column = 0
+    for threshold in _GRID_COLUMN_THRESHOLDS:
+        if x >= threshold:
+            column += 1
+        else:
+            break
+    return column
+
+
 def placeWidget(window,x_coordinate,y_multiplier_integer,widget_name,sameY=False, no_hover_over_widget=False, whole_widget_red=False, centerX=False, basic_y_coordinate=90, x_coordinate_hover_over = 90, text_info=''):
-    # print("widget_name",widget_name,"text_info",text_info)
-    #basic_y_coordinate = 90
-    y_step = 40 #the line-by-line increment on the GUI
+    # CTk migration slice 2b: lay widgets on a GRID instead of absolute .place(x, y=90+40*row).
+    # The legacy row counter (y_multiplier_integer) becomes the grid row; the x-coordinate becomes a
+    # semantic column. The call signature is unchanged so no GUI script needs editing. sameY keeps
+    # the row and advances to the x-derived column; centerX spans all columns, centered.
+    row = _GRID_HEADER_ROWS + int(round(float(y_multiplier_integer)))
     if centerX:
-        widget_name.place(relx=0.5, anchor=tk.CENTER, y=basic_y_coordinate + y_step*y_multiplier_integer)
+        widget_name.grid(row=row, column=0, columnspan=len(_GRID_COLUMN_THRESHOLDS) + 1,
+                         padx=6, pady=3, sticky='')
     else:
-        widget_name.place(x=x_coordinate, y=basic_y_coordinate + y_step*y_multiplier_integer)
-    # use the following command to change the color of any label to any value
-    # widget_name.config(foreground='red')
+        widget_name.grid(row=row, column=_x_to_column(x_coordinate), padx=6, pady=3, sticky='w')
 
-    # when a widget has hover-over effects, the parameter no_hover_over_widget is set to False
-    hover_over_widget(window,x_coordinate, basic_y_coordinate + y_step*y_multiplier_integer,widget_name, no_hover_over_widget, whole_widget_red, x_coordinate_hover_over, text_info)
+    # Tooltip: bind to the widget itself (GUI_theme_util.ToolTip) instead of the old
+    # coordinate-based hover_over_widget -- the absolute coordinates the latter positioned from are
+    # gone under grid. ToolTip works on both tk and CTk widgets. (Lazy import: avoids a module-level
+    # dependency of GUI_IO_util on GUI_theme_util.)
+    if not no_hover_over_widget and text_info != '':
+        import GUI_theme_util
+        GUI_theme_util.ToolTip(widget_name, text_info)
 
-    if sameY==False:
-        y_multiplier_integer = y_multiplier_integer+1
+    if not sameY:
+        y_multiplier_integer = y_multiplier_integer + 1
     return y_multiplier_integer
 
 basic_y_coordinate = 90

--- a/src/GUI_IO_util.py
+++ b/src/GUI_IO_util.py
@@ -1344,6 +1344,10 @@ def Dialog2Display(title: str):
 
 
 def message_box_widget(window, message_title, message_text, buttonType='OK', timeout=3000):
+    # CTk migration: intentionally NOT converted in Phase 1 slice 3. This is a Phase 4 hard case -- the
+    # OK/Yes/No buttons and countdown labels are .place()'d at pixel offsets computed from the packed
+    # tk.Message's height, and this dialog fires on every RUN's Started/Finished notice, so a reskin
+    # needs on-screen QA of that geometry. Left on plain tk until then.
     global yes_no_button
     yes_no_button = ""
     # if not 'Started' in message_text and not 'Finished' in message_text:
@@ -1461,6 +1465,9 @@ def message_box_widget(window, message_title, message_text, buttonType='OK', tim
 # https://pythonguides.com/python-tkinter-search-box/
 # left unfinished
 def combobox_with_search_widget(item_names):
+    # CTk migration: intentionally NOT converted in Phase 1 slice 3. Phase 4 hard case -- the function
+    # is unfinished (its only call site is commented out) and spins its own tk.Tk()/mainloop(); it needs
+    # to be completed, not mechanically reskinned. Left on plain tk until then.
     ws = tk.Tk()
     ws.focus_force()
     ws.title("NLP Suite")
@@ -1503,21 +1510,25 @@ def combobox_with_search_widget(item_names):
 
 # creating popup menu in tkinter
 def dropdown_menu_widget(window,textCaption, menu_values, default_value, callback):
+    # CTk migration slice 3: themed CTkToplevel parented to the caller's window + GUI_theme_util
+    # wrappers. The legacy code packed the combobox and then re-gridded it (the pack call was dead) and
+    # gridded the OK button into the SAME cell (0,1) as the combobox, so they overlapped -- harmless-
+    # looking with translucent tk widgets, visibly broken with opaque CTk ones. The rebuild drops the
+    # dead pack and gives OK its own column.
+    import customtkinter as ctk
+    import GUI_theme_util
 
     class App():
         def __init__(self,master):
-            top = self.top = Toplevel()
+            top = self.top = ctk.CTkToplevel(master)
             top.wm_title(textCaption)
             top.focus_force()
-            self.menuButton = ttk.Combobox(top, width=len(textCaption)+30)
-            self.menuButton['values'] = menu_values
-            self.menuButton.pack() # put the widget on the window
-
-            self.menuButton.grid(row=0, column=1) # , sticky=W)
+            self.menuButton = GUI_theme_util.create_combobox(top, values=menu_values, width=len(textCaption)+30)
+            self.menuButton.grid(row=0, column=1, padx=8, pady=8)
             self.callback = callback
 
-            ok_button = tk.Button(self.top, text='OK', command=self.get_value)
-            ok_button.grid(row=0, column=1)
+            ok_button = GUI_theme_util.create_button(self.top, text='OK', command=self.get_value)
+            ok_button.grid(row=0, column=2, padx=8, pady=8)
 
         def get_value(self):
             val = self.menuButton.get()
@@ -1528,6 +1539,11 @@ def dropdown_menu_widget(window,textCaption, menu_values, default_value, callbac
 
 # modified dropdown_menu_widget that will stay open without command=lambda:
 def dropdown_menu_widget2(window,textCaption, menu_values, default_value, callback):
+    # CTk migration slice 3: themed CTkToplevel + wrappers; same overlap fix as dropdown_menu_widget
+    # (drop the dead pack, OK button into its own column).
+    import customtkinter as ctk
+    import GUI_theme_util
+
     def get_value():
         global val
         val = menuButton.get()
@@ -1535,18 +1551,14 @@ def dropdown_menu_widget2(window,textCaption, menu_values, default_value, callba
         callback(val)
         # top.update()
 
-    top = Toplevel()
+    top = ctk.CTkToplevel(window)
     top.wm_title(textCaption)
     top.focus_force()
-    menuButton = ttk.Combobox(top, width=len(textCaption)+30)
-    menuButton['values'] = menu_values
-    menuButton.pack() # put the widget on the window
+    menuButton = GUI_theme_util.create_combobox(top, values=menu_values, width=len(textCaption)+30)
+    menuButton.grid(row=0, column=1, padx=8, pady=8)
 
-    menuButton.grid(row=0, column=1) # , sticky=W)
-    callback = callback
-
-    ok_button = tk.Button(top, text='OK', command=get_value)
-    ok_button.grid(row=0, column=1)
+    ok_button = GUI_theme_util.create_button(top, text='OK', command=get_value)
+    ok_button.grid(row=0, column=2, padx=8, pady=8)
 
     window.wait_window(top)
 
@@ -1556,25 +1568,37 @@ def slider_widget(window,textCaption, lower_bound, upper_bound, default_value):
     # unattended/silent mode (NLP_SILENT): skip the modal, return the recommended default
     if os.environ.get('NLP_SILENT','').strip().lower() not in ('','0','false','no','off'):
         return default_value
-    top = tk.Toplevel(window)
-    l = tk.Label(top, text= textCaption)
-    l.pack() # put the widget on the window
-    s = tk.Scale(top, from_= lower_bound, to=upper_bound, orient=tk.HORIZONTAL)
-    s.set(default_value)
-    s.pack() # put the widget on the window
+    # CTk migration slice 3: themed CTkToplevel + GUI_theme_util wrappers. Two behaviour-preserving
+    # notes: (1) CTkSlider has no built-in value readout (tk.Scale drew one), so a small label mirrors
+    # the current value; (2) tk.Scale's default resolution is 1 (integer steps) and every caller uses
+    # the result as an integer count, so pin the slider to integer steps and return an int -- CTkSlider
+    # is otherwise continuous and .get() returns a float.
+    import customtkinter as ctk
+    import GUI_theme_util
+    top = ctk.CTkToplevel(window)
+    GUI_theme_util.create_label(top, text=textCaption, wraplength=460).pack(padx=16, pady=(14, 6))
+    value_lb = GUI_theme_util.create_label(top, text=str(default_value))
+    s = GUI_theme_util.create_slider(top, from_=lower_bound, to=upper_bound,
+                                     orient='horizontal', resolution=1, length=300)
+    s.configure(command=lambda v: value_lb.configure(text=str(int(round(float(v))))))
+    try:
+        s.set(float(default_value))
+    except (TypeError, ValueError):
+        s.set(lower_bound)
+    s.pack(padx=16, pady=4)
+    value_lb.pack(pady=(0, 8))
 
     def get_value():
         global val
-        val = s.get()
+        val = int(round(float(s.get())))
         top.destroy()
-        top.update()
 
     def _delete_window():
         mb.showwarning(title = "Invalid Operation", message = "Please click OK to save your choice of parameter.")
 
     top.protocol("WM_DELETE_WINDOW", _delete_window)
 
-    tk.Button(top, text='OK', command=lambda: get_value()).pack()
+    GUI_theme_util.create_button(top, text='OK', command=get_value).pack(pady=(0, 14))
     window.wait_window(top)
     return val
 
@@ -1585,64 +1609,59 @@ def enter_value_widget(masterTitle,textCaption,numberOfWidgets=1,defaultValue=''
     # unattended/silent mode (NLP_SILENT): skip the modal, return the default value(s)
     if os.environ.get('NLP_SILENT','').strip().lower() not in ('','0','false','no','off'):
         return defaultValue, defaultValue2
-    value1=defaultValue
-    value2=defaultValue2
+    # CTk migration slice 3: was a second bare tk.Tk() root driven by its own mainloop(); now a themed
+    # CTkToplevel parented to the suite's root window (GUI_util.window) and driven by wait_window() --
+    # the RUN callback that calls this is already inside that root's mainloop. The entry values are read
+    # into `result` on OK/Return/Escape *before* the window is destroyed, matching the old "quit the
+    # mainloop, then read the entries" flow; closing via the window's X now returns the defaults instead
+    # of raising on a destroyed widget.
+    import customtkinter as ctk
+    import GUI_theme_util
+    import GUI_util
     masterTitle=masterTitle + " (Esc to quit)"
+    result = {'v1': defaultValue, 'v2': defaultValue2}
 
-    # TODO should not restrict to 2; should have a loop
-    if numberOfWidgets==2:
-        # TODO should have a list and break it up assigning values in a loop
-        value2=defaultValue2
-    master = tk.Tk()
+    master = ctk.CTkToplevel(GUI_util.window)
+    master.title(masterTitle)
     master.focus_force()
 
-    tk.Label(master,width=len(textCaption),text=textCaption).grid(row=0)
+    GUI_theme_util.create_label(master, text=textCaption).grid(row=0, column=0, padx=8, pady=6)
     # TODO should not restrict to 2; should have a loop
     if numberOfWidgets==2:
-        tk.Label(master, width=len(textCaption2),text=textCaption2).grid(row=1)
+        GUI_theme_util.create_label(master, text=textCaption2).grid(row=1, column=0, padx=8, pady=6)
 
-    master.title(masterTitle)
-    # the width in tk.Entry determines the overall width of the widget;
-    #   MUST be entered
-    #   + 30 to add room for - [] and X in a widget window
-    e1 = tk.Entry(master,width=len(masterTitle)+30)
+    # the old tk.Entry width was len(masterTitle)+30 characters; keep the character-based width (the
+    # wrapper converts characters -> pixels).
+    e1 = GUI_theme_util.create_entry(master, width=len(masterTitle)+30)
+    e1.grid(row=0, column=1, padx=8, pady=6)
+    # TODO 2 could be a larger number; should have a loop
+    if numberOfWidgets==2:
+        e2 = GUI_theme_util.create_entry(master, width=len(masterTitle)+30)
+        e2.grid(row=1, column=1, padx=8, pady=6)
+
+    e1.insert(0, defaultValue) # display a default value
+    # TODO 2 could be a larger number; should have a loop
+    if numberOfWidgets==2:
+        e2.insert(0, defaultValue2) # display a default value
     e1.focus_force()
 
-    # TODO 2 could be a larger number; should have a loop
-    if numberOfWidgets==2:
-        e2 = tk.Entry(master,width=len(masterTitle)+30)
+    def _accept(event=None):
+        result['v1'] = str(e1.get())
+        # TODO 2 could be a larger number; should have a loop
+        if numberOfWidgets==2:
+            result['v2'] = str(e2.get())
+        master.destroy()
 
-    e1.grid(row=0, column=1)
-    # TODO 2 could be a larger number; should have a loop
-    if numberOfWidgets==2:
-        e2.grid(row=1, column=1)
+    GUI_theme_util.create_button(master, text='OK', command=_accept).grid(row=3, column=0,
+                                                                          sticky='w', padx=8, pady=4)
+    master.bind('<Return>', _accept)
+    master.bind('<Escape>', _accept)
 
-    e1.insert(len(textCaption), defaultValue) # display a default value
-    # TODO 2 could be a larger number; should have a loop
-    if numberOfWidgets==2:
-        e2.insert(len(textCaption2), defaultValue2) # display a default value
-
-    tk.Button(master,
-              text='OK',
-              command=master.quit).grid(row=3,
-                                        column=0,
-                                        sticky=tk.W,
-                                        pady=4)
-    def func(event):
-        master.quit()
-    master.bind('<Return>', func)
-    master.bind('<Escape>', func)
-
-    master.mainloop()
-    value1=str(e1.get())
-    # TODO 2 could be a larger number; should have a loop
-    if numberOfWidgets==2:
-        value2=str(e2.get())
-    master.destroy()
+    master.wait_window()
     # convert to list; value1 is checked for length in calling function
     #   so do not convert if empty or its length will be the length of ['']
     # if value1!='':
     #     value1=list(value1.split(" "))
-    return value1, value2
+    return result['v1'], result['v2']
 
 

--- a/src/GUI_IO_util.py
+++ b/src/GUI_IO_util.py
@@ -472,6 +472,43 @@ def _column_for(row, x_coordinate):
     return column
 
 
+def apply_row_spans(window):
+    """Let every placed widget span from its own column to the next occupied one on its row.
+
+    Grid columns are shared by ALL rows, so a wide widget sitting in a single column forces that
+    column wide for every other row too. A long checkbox label or a long path entry -- effectively
+    alone on its own row -- was therefore inflating the columns that the dense option rows also use,
+    and pushing those rows off the right edge of the window. Spanning restores the pre-grid
+    (absolute-x) semantics: a widget occupies the horizontal space up to wherever the NEXT widget on
+    its row begins, so its width is distributed over that span instead of charged to one shared
+    column. On wordclouds_main this takes the grid's requested width from 2183px to 1496px.
+
+    Call once per GUI, after every widget has been placed (GUI_util.GUI_bottom does this).
+    Widgets that already span deliberately (centerX rows, the header) are left alone.
+    """
+    by_row = {}
+    for child in window.grid_slaves():
+        info = child.grid_info()
+        if int(info.get('columnspan', 1)) > 1:
+            continue
+        by_row.setdefault(int(info['row']), []).append((int(info['column']), child))
+
+    if not by_row:
+        return
+
+    # Stop at the last column anything actually occupies rather than _GRID_TOTAL_COLUMNS: stretching
+    # the trailing widget across the unused tail just spreads padding into empty columns.
+    last_column = max(column for row_items in by_row.values() for column, _ in row_items) + 1
+
+    for row_items in by_row.values():
+        row_items.sort(key=lambda pair: pair[0])
+        for index, (column, child) in enumerate(row_items):
+            next_column = row_items[index + 1][0] if index + 1 < len(row_items) else last_column
+            span = max(1, next_column - column)
+            if span > 1:
+                child.grid_configure(columnspan=span)
+
+
 def placeWidget(window,x_coordinate,y_multiplier_integer,widget_name,sameY=False, no_hover_over_widget=False, whole_widget_red=False, centerX=False, basic_y_coordinate=90, x_coordinate_hover_over = 90, text_info=''):
     # The legacy row counter (y_multiplier_integer) becomes the grid row; the x-coordinate picks the
     # column band on that row (see the module note above). sameY keeps the same row so successive
@@ -481,7 +518,10 @@ def placeWidget(window,x_coordinate,y_multiplier_integer,widget_name,sameY=False
         widget_name.grid(row=row, column=0, columnspan=_GRID_TOTAL_COLUMNS,
                          padx=6, pady=3, sticky='')
     else:
-        widget_name.grid(row=row, column=_column_for(row, x_coordinate), padx=6, pady=3, sticky='w')
+        # padx=4 rather than 6: horizontal padding is charged twice per column, so on a ~9-column GUI
+        # the difference is ~36px -- enough to keep the widest row inside the window without having to
+        # make every GUI wider.
+        widget_name.grid(row=row, column=_column_for(row, x_coordinate), padx=4, pady=3, sticky='w')
 
     # Tooltip: bind to the widget itself (GUI_theme_util.ToolTip) instead of the old
     # coordinate-based hover_over_widget -- the absolute coordinates the latter positioned from are

--- a/src/GUI_IO_util.py
+++ b/src/GUI_IO_util.py
@@ -405,61 +405,77 @@ def hover_over_widget(window, x_coordinate, y_coordinate, widget_name, no_hover_
 # when a widget has hover-over effects, the parameter no_hover_over_widget is set to False
 # widget_name is the name of the widget that needs to be placed in any of the GUI scripts as defined by tk.
 # CTk migration slice 2b: lay widgets on a GRID instead of absolute .place(x, y=90+40*row).
-# A first cut mapped each widget's absolute x-coordinate to a *shared, fixed* column (bucketing x
-# against pixel thresholds). That broke badly: two widgets whose x-values fell in the same band
-# collided in one cell (stacked on top of each other), while sparsely-populated bands left wide
-# empty columns whose width still counted -- so content floated to the far right and, on busier
-# GUIs, spilled off the window's right edge. The absolute pixel positions simply don't survive the
-# translation to a content-sized grid.
 #
-# Instead we assign columns SEQUENTIALLY per row, in call order: column 0 is reserved for the
-# left-most "?HELP / read" zone (x below _HELP_ZONE_MAX), and every subsequent widget on that row
-# takes the next free column (1, 2, 3, ...). This preserves the horizontal ORDER the x-coordinates
-# encoded, guarantees no two widgets collide, and packs left with no stranded empty columns -- so
-# the grid's natural width stays within the window. The call signature is unchanged; no GUI script
-# needs editing.
+# Two earlier cuts each failed one way:
+#   1. Map each x to a *fixed shared column* with fine pixel thresholds. Preserved absolute
+#      position but (a) collided widgets whose x fell in the same band into one cell (stacked on
+#      top of each other) and (b) spread the union of all rows across ~9 columns, so one wide
+#      widget (a file-path entry) pushed the right-hand columns off the window's edge.
+#   2. Assign columns *sequentially in call order* (col 0 = help, then 1, 2, ...). Never collided
+#      and packed compactly, but THREW AWAY absolute position: shared rows that place widgets at
+#      fixed x's out of call order -- above all the bottom chrome (Read Me | videos | TIPS |
+#      reminders | SETUP | RUN | CLOSE, RUN at x=940 and CLOSE at x=1090) -- had RUN/CLOSE
+#      appended after the (wide) SETUP widget and shoved off-screen. RUN vanished on every GUI.
+#
+# This version keeps position AND avoids both failures: bucket x into a SMALL number of coarse,
+# order-preserving bands (so RUN lands right, Read Me lands left, labels/entries line up), and on a
+# collision within a row BUMP to the next free column instead of stacking. Coarse bands (6, not 9)
+# keep the populated-column count -- and therefore the total width -- inside the window; the bump
+# guarantees no two widgets ever share a cell. Call signature unchanged; no GUI script needs editing.
 
-# Widgets whose legacy x is below this belong in the reserved left-most column (the "? HELP" /
-# "read" button that opens most rows). Both the darwin (help_button_x=70) and Windows constant
-# blocks put that button near x=70, well under this cutoff.
-_HELP_ZONE_MAX = 130
+# Coarse left-to-right band edges. A widget's base column = how many edges its x is >= (so x<130 ->
+# col 0, the "?HELP / Read Me / read" zone; x>=900 -> col 5, the RUN/CLOSE zone). Chosen so the
+# bottom-chrome x's (70/200/370/570/770/940/1090 on Mac; similar on Windows) distribute one-per-band
+# across cols 0..5, and the per-GUI label/control x's fall in sensible bands. Magnitudes are
+# comparable across the darwin and Windows constant blocks, so one set of edges serves both.
+_GRID_COLUMN_THRESHOLDS = (130, 330, 520, 700, 900)
 # Top grid rows reserved for the header (intro text + logo); placeWidget content starts below.
 _GRID_HEADER_ROWS = 1
 # Generous fixed span for full-width (centerX) rows and the header intro. Grid columns with no
 # content collapse to zero width, so over-spanning is harmless.
 _GRID_TOTAL_COLUMNS = 16
 
-# Per-build layout state: next free content column for each grid row, and which rows have already
-# claimed the reserved help column. Reset at the start of each GUI build via _reset_grid_layout().
-_grid_row_next_col = {}
-_grid_row_help_used = set()
+# Per-build layout state: the set of columns already occupied on each grid row (so a collision can
+# bump right to the next free one). Reset at the start of each GUI build via _reset_grid_layout().
+_grid_row_used_cols = {}
 
 
 def _reset_grid_layout():
     """Clear per-row column bookkeeping so a freshly built GUI starts from an empty grid."""
-    _grid_row_next_col.clear()
-    _grid_row_help_used.clear()
+    _grid_row_used_cols.clear()
 
 
-def _column_for(row, x_coordinate):
-    """Next grid column for a widget on `row`: column 0 for the first help-zone widget, otherwise
-    the next free column left-to-right. Preserves call order without ever colliding two widgets."""
+def _base_column(x_coordinate):
+    """Coarse, order-preserving band for a legacy absolute x-coordinate (0 = leftmost)."""
     try:
         x = float(x_coordinate)
     except (TypeError, ValueError):
-        x = None
-    if x is not None and x < _HELP_ZONE_MAX and row not in _grid_row_help_used:
-        _grid_row_help_used.add(row)
-        return 0
-    column = _grid_row_next_col.get(row, 1)
-    _grid_row_next_col[row] = column + 1
+        return 1
+    column = 0
+    for edge in _GRID_COLUMN_THRESHOLDS:
+        if x >= edge:
+            column += 1
+        else:
+            break
+    return column
+
+
+def _column_for(row, x_coordinate):
+    """Grid column for a widget on `row`: its x-derived band, bumped right to the next free column
+    if that band is already taken on this row. Preserves horizontal position without ever stacking
+    two widgets in one cell."""
+    used = _grid_row_used_cols.setdefault(row, set())
+    column = _base_column(x_coordinate)
+    while column in used:
+        column += 1
+    used.add(column)
     return column
 
 
 def placeWidget(window,x_coordinate,y_multiplier_integer,widget_name,sameY=False, no_hover_over_widget=False, whole_widget_red=False, centerX=False, basic_y_coordinate=90, x_coordinate_hover_over = 90, text_info=''):
-    # The legacy row counter (y_multiplier_integer) becomes the grid row; the x-coordinate now only
-    # decides ordering within that row (see the module note above). sameY keeps the same row so the
-    # next call lands in the next column over; centerX spans the full width, centered.
+    # The legacy row counter (y_multiplier_integer) becomes the grid row; the x-coordinate picks the
+    # column band on that row (see the module note above). sameY keeps the same row so successive
+    # calls fill it left to right; centerX spans the full width, centered.
     row = _GRID_HEADER_ROWS + int(round(float(y_multiplier_integer)))
     if centerX:
         widget_name.grid(row=row, column=0, columnspan=_GRID_TOTAL_COLUMNS,

--- a/src/GUI_IO_util.py
+++ b/src/GUI_IO_util.py
@@ -110,7 +110,10 @@ remindersPath = os.path.join(NLPPath, 'reminders')
 
 # The function places and displays a message for each ? HELP button in the GUIs
 def place_help_button(window,x_coordinate,y_coordinate,text_title,text_info):
-    help_button = tk.Button(window, text='? HELP', command=lambda: display_help_button_info(text_title, text_info))
+    import GUI_theme_util
+    # Give '? HELP' an explicit character width so CTk doesn't fall back to its 140px default
+    # (which makes every help button look oversized). 10 chars matches the Read Me/RUN chrome buttons.
+    help_button = GUI_theme_util.create_button(window, text='? HELP', width=10, command=lambda: display_help_button_info(text_title, text_info))
     # place widget with hover-over info
     y_multiplier_integer = placeWidget(window, x_coordinate,
                                                    y_coordinate,
@@ -222,6 +225,23 @@ def hover_over_widget(window, x_coordinate, y_coordinate, widget_name, no_hover_
                     whole_widget_red=False, x_coordinate_hover_over= 90, text_info=''):
     if no_hover_over_widget:
         return
+
+    # CTk migration (Phase 1 slice 2a): CustomTkinter widgets draw themselves and do NOT support
+    # tk's .cget('background') / .config(background=...) -- the red/green color-flip machinery below
+    # would raise on them. CTk widgets already have a built-in hover_color, so they need no color
+    # flip: give them a TOOLTIP-ONLY hover (show text_info on <Enter>, dismiss on <Leave>/click),
+    # then return before the tk-specific code. The tk path below is untouched for plain tk widgets.
+    if 'customtkinter' in type(widget_name).__module__:
+        if text_info != '':
+            number_of_lines = text_info.count('\n')
+            y_offset = 20 if number_of_lines == 0 else (25 if number_of_lines == 1 else 30)
+            tip_y = y_coordinate - y_offset
+            widget_name.bind('<Enter>', lambda e: display_widget_info(
+                window, e, x_coordinate, tip_y, x_coordinate_hover_over, text_info), add='+')
+            widget_name.bind('<Leave>', lambda e: delete_display_widget_lb(window, e, text_info), add='+')
+            widget_name.bind('<Button>', lambda e: delete_display_widget_lb(window, e, text_info), add='+')
+        return
+
     # hover-over effect
     # background = 'red' sets the whole widget in red
     # background='#F0F0F0' sets the widget in grey

--- a/src/GUI_IO_util.py
+++ b/src/GUI_IO_util.py
@@ -404,42 +404,68 @@ def hover_over_widget(window, x_coordinate, y_coordinate, widget_name, no_hover_
 
 # when a widget has hover-over effects, the parameter no_hover_over_widget is set to False
 # widget_name is the name of the widget that needs to be placed in any of the GUI scripts as defined by tk.
-# CTk migration slice 2b: the legacy per-GUI absolute x-coordinate constants cluster into a handful
-# of left-to-right bands. Bucketing an x-value against these thresholds preserves the horizontal
-# ORDER of widgets on a row while dropping the exact pixel spacing (that is the point of the reflow:
-# grid columns are content-sized). Works for both the darwin and Windows constant blocks since their
-# magnitudes are comparable.
-_GRID_COLUMN_THRESHOLDS = (110, 250, 400, 560, 720, 900, 1020, 1120)
+# CTk migration slice 2b: lay widgets on a GRID instead of absolute .place(x, y=90+40*row).
+# A first cut mapped each widget's absolute x-coordinate to a *shared, fixed* column (bucketing x
+# against pixel thresholds). That broke badly: two widgets whose x-values fell in the same band
+# collided in one cell (stacked on top of each other), while sparsely-populated bands left wide
+# empty columns whose width still counted -- so content floated to the far right and, on busier
+# GUIs, spilled off the window's right edge. The absolute pixel positions simply don't survive the
+# translation to a content-sized grid.
+#
+# Instead we assign columns SEQUENTIALLY per row, in call order: column 0 is reserved for the
+# left-most "?HELP / read" zone (x below _HELP_ZONE_MAX), and every subsequent widget on that row
+# takes the next free column (1, 2, 3, ...). This preserves the horizontal ORDER the x-coordinates
+# encoded, guarantees no two widgets collide, and packs left with no stranded empty columns -- so
+# the grid's natural width stays within the window. The call signature is unchanged; no GUI script
+# needs editing.
+
+# Widgets whose legacy x is below this belong in the reserved left-most column (the "? HELP" /
+# "read" button that opens most rows). Both the darwin (help_button_x=70) and Windows constant
+# blocks put that button near x=70, well under this cutoff.
+_HELP_ZONE_MAX = 130
 # Top grid rows reserved for the header (intro text + logo); placeWidget content starts below.
 _GRID_HEADER_ROWS = 1
+# Generous fixed span for full-width (centerX) rows and the header intro. Grid columns with no
+# content collapse to zero width, so over-spanning is harmless.
+_GRID_TOTAL_COLUMNS = 16
+
+# Per-build layout state: next free content column for each grid row, and which rows have already
+# claimed the reserved help column. Reset at the start of each GUI build via _reset_grid_layout().
+_grid_row_next_col = {}
+_grid_row_help_used = set()
 
 
-def _x_to_column(x_coordinate):
-    """Map a legacy absolute x-coordinate to a semantic grid column index (0 = leftmost)."""
+def _reset_grid_layout():
+    """Clear per-row column bookkeeping so a freshly built GUI starts from an empty grid."""
+    _grid_row_next_col.clear()
+    _grid_row_help_used.clear()
+
+
+def _column_for(row, x_coordinate):
+    """Next grid column for a widget on `row`: column 0 for the first help-zone widget, otherwise
+    the next free column left-to-right. Preserves call order without ever colliding two widgets."""
     try:
         x = float(x_coordinate)
     except (TypeError, ValueError):
-        return 1
-    column = 0
-    for threshold in _GRID_COLUMN_THRESHOLDS:
-        if x >= threshold:
-            column += 1
-        else:
-            break
+        x = None
+    if x is not None and x < _HELP_ZONE_MAX and row not in _grid_row_help_used:
+        _grid_row_help_used.add(row)
+        return 0
+    column = _grid_row_next_col.get(row, 1)
+    _grid_row_next_col[row] = column + 1
     return column
 
 
 def placeWidget(window,x_coordinate,y_multiplier_integer,widget_name,sameY=False, no_hover_over_widget=False, whole_widget_red=False, centerX=False, basic_y_coordinate=90, x_coordinate_hover_over = 90, text_info=''):
-    # CTk migration slice 2b: lay widgets on a GRID instead of absolute .place(x, y=90+40*row).
-    # The legacy row counter (y_multiplier_integer) becomes the grid row; the x-coordinate becomes a
-    # semantic column. The call signature is unchanged so no GUI script needs editing. sameY keeps
-    # the row and advances to the x-derived column; centerX spans all columns, centered.
+    # The legacy row counter (y_multiplier_integer) becomes the grid row; the x-coordinate now only
+    # decides ordering within that row (see the module note above). sameY keeps the same row so the
+    # next call lands in the next column over; centerX spans the full width, centered.
     row = _GRID_HEADER_ROWS + int(round(float(y_multiplier_integer)))
     if centerX:
-        widget_name.grid(row=row, column=0, columnspan=len(_GRID_COLUMN_THRESHOLDS) + 1,
+        widget_name.grid(row=row, column=0, columnspan=_GRID_TOTAL_COLUMNS,
                          padx=6, pady=3, sticky='')
     else:
-        widget_name.grid(row=row, column=_x_to_column(x_coordinate), padx=6, pady=3, sticky='w')
+        widget_name.grid(row=row, column=_column_for(row, x_coordinate), padx=6, pady=3, sticky='w')
 
     # Tooltip: bind to the widget itself (GUI_theme_util.ToolTip) instead of the old
     # coordinate-based hover_over_widget -- the absolute coordinates the latter positioned from are

--- a/src/GUI_theme_util.py
+++ b/src/GUI_theme_util.py
@@ -35,8 +35,20 @@ import customtkinter as ctk
 
 import ctk_bundle_util
 
-# NLP Suite brand accent (see GUI_util.py "RGB red is #b10a0a"). Mirrored in nlp_suite_theme.json.
+# NLP Suite brand accent (see GUI_util.py "RGB red is #b10a0a"). The theme's default widget fill is
+# NEUTRAL GREY (see nlp_suite_theme.json + the plan's §0): red is a *signal*, not the default. It is
+# opted into via ``accent=True`` on create_button / create_option_menu, and only two things earn it --
+# the RUN primary-action button and the "available" state of the TIPS / videos / reminders dropdowns.
+# The first migration cut painted every widget this red; that erased the red=available cue and was
+# reverted. Light-mode value first, dark-mode second (CTk color pairs); appearance is pinned "light"
+# in Phase 1 but both are supplied so the accent survives a later dark-mode enable.
 NLP_SUITE_ACCENT = "#b10a0a"
+_ACCENT_FG = ["#b10a0a", "#c81414"]
+_ACCENT_HOVER = ["#8a0808", "#9e0d0d"]
+_ACCENT_TEXT = ["#FFFFFF", "#F5E9E9"]
+# The OptionMenu arrow-button portion is a shade darker than the body, matching CTk's convention.
+_ACCENT_MENU_BUTTON = ["#8a0808", "#9e0d0d"]
+_ACCENT_MENU_BUTTON_HOVER = ["#6d0606", "#7a0a0a"]
 
 # Legacy tk widths are in characters; CTk widths are in pixels. Rough average glyph advance for the
 # suite's UI font. Tuned once here; per-call-site tweaks happen during the pilot/batch phases.
@@ -175,8 +187,20 @@ def translate_kwargs(cls, kwargs, width_is_chars=True, height_is_lines=True):
 # ---------------------------------------------------------------------------------------------
 
 
-def create_button(master, **kwargs):
-    return ctk.CTkButton(master, **translate_kwargs(ctk.CTkButton, kwargs))
+def create_button(master, accent=False, **kwargs):
+    """tk.Button(...) -> CTkButton(...).
+
+    ``accent=True`` paints the button in the brand red instead of the neutral theme default -- used
+    for the single RUN primary-action button per GUI (the one control that earns the accent among
+    buttons; see the plan's §0). An explicit ``fg_color``/``hover_color``/``text_color`` at the call
+    site still wins, so the accent is only a default.
+    """
+    translated = translate_kwargs(ctk.CTkButton, kwargs)
+    if accent:
+        translated.setdefault("fg_color", _ACCENT_FG)
+        translated.setdefault("hover_color", _ACCENT_HOVER)
+        translated.setdefault("text_color", _ACCENT_TEXT)
+    return ctk.CTkButton(master, **translated)
 
 
 # The small "open the selected file / directory" affordance. The legacy `width=1, text=''` rendered
@@ -228,31 +252,41 @@ def create_checkbox(master, **kwargs):
     return ctk.CTkCheckBox(master, **translated)
 
 
-# Neutral grey for a "nothing available" OptionMenu (muted=True). The theme paints every menu solid
-# red, which erased the legacy red=available / black=none availability cue on the TIPS / reminders /
-# videos dropdowns. Grey-on-red restores that cue in a CTk-native way -- a greyed dropdown reads as
-# "nothing here for this GUI" at a glance. Light-mode values (appearance is pinned "light" in Phase 1).
+# The TIPS / videos / reminders dropdowns carry a three-state availability cue:
+#   * accent=True -> brand RED: a resource IS available for this GUI (the legacy "red" state).
+#   * default     -> neutral GREY (the theme default): an ordinary control, no special meaning.
+#   * muted=True  -> a LIGHTER washed-out grey: explicitly "nothing available for this GUI".
+# muted is deliberately lighter than the neutral default so "no resource here" reads as inert rather
+# than merely un-accented. Light-mode values (appearance is pinned "light" in Phase 1).
 _MUTED_FG = "#d9d9d9"
 _MUTED_BUTTON = "#c4c4c4"
 _MUTED_BUTTON_HOVER = "#b4b4b4"
 _MUTED_TEXT = "#5f5f5f"
 
 
-def create_option_menu(
-    master, variable=None, values=None, command=None, muted=False, **kwargs
-):
+def create_option_menu(master, variable=None, values=None, command=None, muted=False, accent=False, **kwargs):
     """tk.OptionMenu(master, var, *choices) -> CTkOptionMenu(master, variable=, values=[...]).
 
     The legacy call passes the choices as varargs; call sites converting to this factory pass them
     as ``values=[...]``. Repopulate a live menu with :func:`set_values` (never the old
     ``widget["menu"]`` mutation).
 
-    muted=True renders the menu in a neutral GREY instead of the theme red -- used for the
-    TIPS / reminders / videos dropdowns when nothing is available for the current GUI, restoring the
-    legacy red=available / grey=none availability cue the solid-red theme otherwise erased.
+    The theme default is a neutral grey (red is not the default fill -- see the plan's §0). The two
+    flags opt into the availability cue on the TIPS / videos / reminders dropdowns:
+
+    * ``accent=True`` -> brand RED, i.e. a resource IS available for this GUI.
+    * ``muted=True``  -> a lighter grey, i.e. nothing is available for this GUI.
+
+    They are complements; passing neither leaves the neutral default (used by ordinary dropdowns like
+    the Setup and I/O-config menus). ``accent`` takes precedence if both are somehow passed.
     """
     translated = translate_kwargs(ctk.CTkOptionMenu, kwargs)
-    if muted:
+    if accent:
+        translated.setdefault("fg_color", _ACCENT_FG)
+        translated.setdefault("button_color", _ACCENT_MENU_BUTTON)
+        translated.setdefault("button_hover_color", _ACCENT_MENU_BUTTON_HOVER)
+        translated.setdefault("text_color", _ACCENT_TEXT)
+    elif muted:
         translated.setdefault("fg_color", _MUTED_FG)
         translated.setdefault("button_color", _MUTED_BUTTON)
         translated.setdefault("button_hover_color", _MUTED_BUTTON_HOVER)

--- a/src/GUI_theme_util.py
+++ b/src/GUI_theme_util.py
@@ -149,14 +149,15 @@ def _accepted_params(cls):
     }
 
 
-def translate_kwargs(cls, kwargs, width_is_chars=True, height_is_lines=True):
+def translate_kwargs(cls, kwargs, width_is_chars=True, height_is_lines=True, width_padding=0):
     """Translate legacy tk widget kwargs into kwargs valid for CustomTkinter class ``cls``.
 
     Pure function (no widget is created), so it is unit-testable against the real CTk classes via
     signature introspection without a display. Rules:
 
     * ``foreground``/``fg`` -> ``text_color``.
-    * ``width`` (characters) -> pixels via :func:`char_width_to_px` when ``width_is_chars``.
+    * ``width`` (characters) -> pixels via :func:`char_width_to_px` when ``width_is_chars``,
+      plus ``width_padding`` px of chrome allowance (see :func:`create_entry`).
     * ``height`` (lines) -> pixels via :func:`line_height_to_px` when ``height_is_lines``.
     * native-tk chrome kwargs (``relief``, ``bd``, ``bg``, ...) are dropped.
     * anything the target CTk class does not accept is dropped (never passed through blindly).
@@ -167,7 +168,7 @@ def translate_kwargs(cls, kwargs, width_is_chars=True, height_is_lines=True):
         if key in _DROP:
             continue
         if key == "width" and width_is_chars:
-            value = char_width_to_px(value)
+            value = char_width_to_px(value, padding=width_padding)
             if value is None:
                 continue
         elif key == "height" and height_is_lines:
@@ -229,10 +230,20 @@ def create_label(master, **kwargs):
     return ctk.CTkLabel(master, **translate_kwargs(ctk.CTkLabel, kwargs))
 
 
+# A CTkEntry reserves internal horizontal padding around its text area, so a bare chars*px width
+# yields fewer usable character cells than the legacy tk.Entry did. That is invisible on the wide
+# file-path entries but clips the small ones: the Phase 2 pilot's 4-char "Max no. of words" box
+# rendered "100" as "10C". Add the chrome back so a width=N entry still shows N characters.
+_ENTRY_PADDING_PX = 14
+
+
 def create_entry(master, **kwargs):
     # tk.Entry has no height; only width is character-based.
     return ctk.CTkEntry(
-        master, **translate_kwargs(ctk.CTkEntry, kwargs, height_is_lines=False)
+        master,
+        **translate_kwargs(
+            ctk.CTkEntry, kwargs, height_is_lines=False, width_padding=_ENTRY_PADDING_PX
+        ),
     )
 
 

--- a/src/GUI_theme_util.py
+++ b/src/GUI_theme_util.py
@@ -1,0 +1,437 @@
+"""GUI_theme_util -- CustomTkinter compatibility layer for the NLP Suite.
+
+Part of the CustomTkinter migration (docs/CustomTkinter-Migration-Plan.md, Phase 1). This module is
+the single place that owns CTk setup and the thin factory wrappers that let ~50 legacy GUI scripts
+stop calling ``tk.Button(...)`` / ``tk.OptionMenu(...)`` directly and instead call
+``GUI_theme_util.create_button(...)`` etc. The wrappers accept the *old tk-style keyword arguments*
+(character-based ``width=``, ``foreground=``, tk-only chrome like ``relief=``/``bd=``) and translate
+them to CustomTkinter equivalents (pixel-based ``width=``, ``text_color=``, unsupported kwargs
+dropped), so the mechanical per-file conversion in later phases is a near-verbatim call-site rename.
+
+Design notes
+------------
+* **Introspection-driven translation.** Rather than hand-maintaining a per-widget allow/deny list
+  (which drifts as CustomTkinter changes -- e.g. CTk 6.0.0's ``CTkLabel`` has no ``justify``, and
+  ``CTkEntry`` has neither ``justify`` nor ``anchor``), every wrapper filters the translated kwargs
+  against the *actual* accepted parameters of the target CTk class, read once via
+  ``inspect.signature``. A tk-only kwarg that has no CTk home is silently dropped rather than
+  crashing the constructor.
+* **Character widths -> pixels.** Legacy ``tk.Entry(width=30)`` means 30 characters;
+  ``CTkEntry(width=300)`` means 300 pixels. ``char_width_to_px`` / ``line_height_to_px`` do the
+  conversion (§5.2 of the plan). These are pure and unit-tested.
+* **No import-time side effects beyond importing CTk.** Loading a theme and setting the appearance
+  mode happen only when ``init_appearance()`` is called (from the CTk bootstrap in Phase 2's
+  GUI_util rewrite), never at import, so this module can be imported headlessly in tests.
+
+This module is a pure addition in Phase 1 PR 1: nothing in ``src/`` imports it yet. Phase 1 PR 2
+wires ``GUI_util`` / ``GUI_IO_util`` onto it.
+"""
+
+import inspect
+import tkinter as tk
+import warnings
+
+import customtkinter as ctk
+
+import ctk_bundle_util
+
+# NLP Suite brand accent (see GUI_util.py "RGB red is #b10a0a"). Mirrored in nlp_suite_theme.json.
+NLP_SUITE_ACCENT = "#b10a0a"
+
+# Legacy tk widths are in characters; CTk widths are in pixels. Rough average glyph advance for the
+# suite's UI font. Tuned once here; per-call-site tweaks happen during the pilot/batch phases.
+_PX_PER_CHAR = 8
+# Legacy tk heights (buttons/labels/text) are in text lines; CTk heights are in pixels.
+_PX_PER_LINE = 22
+# A CTk widget's natural (default) height, used as the floor when translating small line counts.
+_MIN_WIDGET_PX = 28
+
+# tk keyword -> CTk keyword renames. (Colors: tk ``foreground``/``fg`` -> CTk ``text_color``.)
+_RENAME = {
+    "foreground": "text_color",
+    "fg": "text_color",
+}
+
+# tk keywords that describe native-widget chrome CTk draws itself (or the theme owns). Dropped
+# outright so they never reach a CTk constructor even if some future CTk class grows a like-named
+# parameter with different semantics. Background colors are dropped rather than mapped to
+# ``fg_color`` so a legacy ``bg='SystemButtonFace'`` can't stomp the themed accent.
+_DROP = frozenset(
+    {
+        "bg",
+        "background",
+        "activebackground",
+        "activeforeground",
+        "disabledforeground",
+        "highlightbackground",
+        "highlightcolor",
+        "highlightthickness",
+        "bd",
+        "borderwidth",
+        "relief",
+        "overrelief",
+        "offrelief",
+        "selectcolor",
+        "indicatoron",
+        "padx",
+        "pady",
+        "takefocus",
+        "repeatdelay",
+        "repeatinterval",
+        "cursor",
+        "underline",
+        "default",
+        "wraplength",  # tk wraplength is in pixels but rarely matched to CTk metrics; let CTk reflow.
+    }
+)
+
+
+def char_width_to_px(char_width, px_per_char=_PX_PER_CHAR, padding=0):
+    """Translate a legacy tk character-based width into a CTk pixel width.
+
+    The input is *always* treated as a character count -- there is no magnitude cutoff that guesses
+    "this looks big, it must already be pixels". Legacy char widths in the suite run past 200 (wide
+    file-path and search entries), so any such guess would shrink exactly the widest fields. A caller
+    that genuinely holds a pixel width bypasses this multiply via ``width_is_chars=False`` in
+    :func:`translate_kwargs` (see :func:`create_slider`) instead.
+
+    Returns ``None`` for a missing / non-positive / non-numeric width so the caller can drop the
+    ``width`` kwarg entirely and let CTk use its own default sizing.
+    """
+    try:
+        n = int(char_width)
+    except (TypeError, ValueError):
+        return None
+    if n <= 0:
+        return None
+    return n * px_per_char + padding
+
+
+def line_height_to_px(char_height):
+    """Translate a legacy tk line-based height (e.g. a 2-line RUN button) into a CTk pixel height.
+
+    Like :func:`char_width_to_px`, the input is always treated as a line count -- pixel-holding
+    callers use ``height_is_lines=False`` in :func:`translate_kwargs` (as :func:`create_entry` does)
+    rather than relying on a magnitude guess.
+
+    Returns ``None`` for a missing / non-positive / non-numeric height so the caller drops the
+    ``height`` kwarg and CTk uses its default widget height.
+    """
+    try:
+        n = int(char_height)
+    except (TypeError, ValueError):
+        return None
+    if n <= 0:
+        return None
+    return max(_MIN_WIDGET_PX, n * _PX_PER_LINE)
+
+
+def _accepted_params(cls):
+    """The set of keyword parameters ``cls.__init__`` accepts (minus self/master/*args/**kwargs)."""
+    params = inspect.signature(cls.__init__).parameters
+    return {
+        name
+        for name, p in params.items()
+        if name not in ("self", "master", "args", "kwargs") and p.kind not in (p.VAR_POSITIONAL, p.VAR_KEYWORD)
+    }
+
+
+def translate_kwargs(cls, kwargs, width_is_chars=True, height_is_lines=True):
+    """Translate legacy tk widget kwargs into kwargs valid for CustomTkinter class ``cls``.
+
+    Pure function (no widget is created), so it is unit-testable against the real CTk classes via
+    signature introspection without a display. Rules:
+
+    * ``foreground``/``fg`` -> ``text_color``.
+    * ``width`` (characters) -> pixels via :func:`char_width_to_px` when ``width_is_chars``.
+    * ``height`` (lines) -> pixels via :func:`line_height_to_px` when ``height_is_lines``.
+    * native-tk chrome kwargs (``relief``, ``bd``, ``bg``, ...) are dropped.
+    * anything the target CTk class does not accept is dropped (never passed through blindly).
+    """
+    accepted = _accepted_params(cls)
+    out = {}
+    for key, value in kwargs.items():
+        if key in _DROP:
+            continue
+        if key == "width" and width_is_chars:
+            value = char_width_to_px(value)
+            if value is None:
+                continue
+        elif key == "height" and height_is_lines:
+            value = line_height_to_px(value)
+            if value is None:
+                continue
+        key = _RENAME.get(key, key)
+        if key in accepted:
+            out[key] = value
+        # else: a tk-only kwarg with no CTk equivalent -- drop it silently.
+    return out
+
+
+# ---------------------------------------------------------------------------------------------
+# Widget factories. Each mirrors the tk constructor call signature its call sites already use
+# (master first, then keyword args) so the mechanical conversion is a name swap.
+# ---------------------------------------------------------------------------------------------
+
+
+def create_button(master, **kwargs):
+    return ctk.CTkButton(master, **translate_kwargs(ctk.CTkButton, kwargs))
+
+
+# The small "open the selected file / directory" affordance. The legacy `width=1, text=''` rendered
+# these as ~8px empty slivers (the red bars / gray box users read as broken). A folder glyph plus a
+# real width makes them read as buttons. Kept in one place so the glyph can be swapped in a single
+# edit if a platform's Tk font renders emoji as a tofu box (fallback: '...').
+OPEN_FILE_GLYPH = '\U0001F4C2'  # 📂
+
+
+def create_open_file_button(master, command=None, width=32, **kwargs):
+    """Small themed icon button for the 'open selected file/directory' action.
+
+    Built directly on CTkButton (not via :func:`create_button`) so ``width`` is honoured as pixels:
+    the char->px translation in ``create_button`` treats any width <= 60 as a character count, so a
+    ~30px icon button can't be expressed through it. Any leftover legacy ``text``/``width`` kwargs
+    are dropped in favour of the fixed glyph and the pixel width.
+    """
+    kwargs.pop('text', None)
+    kwargs.pop('width', None)
+    translated = translate_kwargs(ctk.CTkButton, kwargs)
+    translated['width'] = width
+    return ctk.CTkButton(master, text=OPEN_FILE_GLYPH, command=command, **translated)
+
+
+def create_label(master, **kwargs):
+    return ctk.CTkLabel(master, **translate_kwargs(ctk.CTkLabel, kwargs))
+
+
+def create_entry(master, **kwargs):
+    # tk.Entry has no height; only width is character-based.
+    return ctk.CTkEntry(master, **translate_kwargs(ctk.CTkEntry, kwargs, height_is_lines=False))
+
+
+def create_checkbox(master, **kwargs):
+    return ctk.CTkCheckBox(master, **translate_kwargs(ctk.CTkCheckBox, kwargs))
+
+
+# Neutral grey for a "nothing available" OptionMenu (muted=True). The theme paints every menu solid
+# red, which erased the legacy red=available / black=none availability cue on the TIPS / reminders /
+# videos dropdowns. Grey-on-red restores that cue in a CTk-native way -- a greyed dropdown reads as
+# "nothing here for this GUI" at a glance. Light-mode values (appearance is pinned "light" in Phase 1).
+_MUTED_FG = "#d9d9d9"
+_MUTED_BUTTON = "#c4c4c4"
+_MUTED_BUTTON_HOVER = "#b4b4b4"
+_MUTED_TEXT = "#5f5f5f"
+
+
+def create_option_menu(master, variable=None, values=None, command=None, muted=False, **kwargs):
+    """tk.OptionMenu(master, var, *choices) -> CTkOptionMenu(master, variable=, values=[...]).
+
+    The legacy call passes the choices as varargs; call sites converting to this factory pass them
+    as ``values=[...]``. Repopulate a live menu with :func:`set_values` (never the old
+    ``widget["menu"]`` mutation).
+
+    muted=True renders the menu in a neutral GREY instead of the theme red -- used for the
+    TIPS / reminders / videos dropdowns when nothing is available for the current GUI, restoring the
+    legacy red=available / grey=none availability cue the solid-red theme otherwise erased.
+    """
+    translated = translate_kwargs(ctk.CTkOptionMenu, kwargs)
+    if muted:
+        translated.setdefault("fg_color", _MUTED_FG)
+        translated.setdefault("button_color", _MUTED_BUTTON)
+        translated.setdefault("button_hover_color", _MUTED_BUTTON_HOVER)
+        translated.setdefault("text_color", _MUTED_TEXT)
+    if variable is not None:
+        translated["variable"] = variable
+    if values is not None:
+        translated["values"] = list(values)
+    if command is not None:
+        translated["command"] = command
+    return ctk.CTkOptionMenu(master, **translated)
+
+
+def create_combobox(master, values=None, **kwargs):
+    translated = translate_kwargs(ctk.CTkComboBox, kwargs)
+    if values is not None:
+        translated["values"] = list(values)
+    return ctk.CTkComboBox(master, **translated)
+
+
+def create_slider(master, from_=None, to=None, length=None, orient=None, resolution=None, **kwargs):
+    """tk.Scale(...) -> CTkSlider(...).
+
+    Maps the tk names CTk renamed: ``length`` (px long dimension) -> ``width``, ``orient`` ->
+    ``orientation``, and ``resolution`` (step size) -> ``number_of_steps`` when a range is known.
+    CTkSlider has no built-in value label; call sites that need one add a small CTkLabel bound to
+    the same variable (the legacy ``slider_widget`` popup already does this by hand).
+    """
+    translated = translate_kwargs(ctk.CTkSlider, kwargs, width_is_chars=False, height_is_lines=False)
+    if from_ is not None:
+        translated["from_"] = from_
+    if to is not None:
+        translated["to"] = to
+    if length is not None:
+        translated["width"] = length
+    if orient is not None:
+        translated["orientation"] = orient
+    if resolution and from_ is not None and to is not None:
+        try:
+            steps = int(round((float(to) - float(from_)) / float(resolution)))
+            if steps > 0:
+                translated["number_of_steps"] = steps
+        except (TypeError, ValueError, ZeroDivisionError):
+            pass
+    return ctk.CTkSlider(master, **translated)
+
+
+def create_textbox(master, **kwargs):
+    # tk.Text width is characters, height is lines; CTkTextbox has a built-in scrollbar so the
+    # manual tk.Scrollbar pairing at the call site is dropped during conversion.
+    return ctk.CTkTextbox(master, **translate_kwargs(ctk.CTkTextbox, kwargs))
+
+
+def set_values(widget, values, default=None):
+    """Repopulate a CTkOptionMenu / CTkComboBox's items -- the CTk replacement for the legacy
+    ``menu = widget["menu"]; menu.delete(0, "end"); menu.add_command(...)`` idiom.
+
+    Pass ``default`` to also select an item (e.g. the first) after repopulating. Returns the
+    normalized list actually set.
+    """
+    values = list(values)
+    widget.configure(values=values)
+    if default is not None:
+        widget.set(default)
+    return values
+
+
+class ToolTip:
+    """Lightweight hover tooltip bound to a widget's ``<Enter>``/``<Leave>`` events.
+
+    Replaces the coordinate-based ``GUI_IO_util.hover_over_widget`` / ``display_widget_info``
+    machinery, which reconstructed popup positions from the same absolute pixel constants the grid
+    migration removes. Bind to the widget itself instead; the ``text`` strings (the suite's main
+    in-app documentation) are preserved verbatim by the callers. The tooltip surface is a plain
+    ``tk.Toplevel`` (the classic yellow tip), which renders fine under a CTk root and needs no CTk
+    theming of its own.
+    """
+
+    def __init__(self, widget, text, delay_ms=500, wraplength=420):
+        self.widget = widget
+        self.text = text or ""
+        self.delay_ms = delay_ms
+        self.wraplength = wraplength
+        self._after_id = None
+        self._tip = None
+        widget.bind("<Enter>", self._schedule, add="+")
+        widget.bind("<Leave>", self._hide, add="+")
+        widget.bind("<ButtonPress>", self._hide, add="+")
+
+    def _schedule(self, _event=None):
+        self._cancel()
+        if self.text:
+            self._after_id = self.widget.after(self.delay_ms, self._show)
+
+    def _cancel(self):
+        if self._after_id is not None:
+            try:
+                self.widget.after_cancel(self._after_id)
+            except Exception:
+                pass
+            self._after_id = None
+
+    def _show(self):
+        if self._tip is not None or not self.text:
+            return
+        try:
+            x = self.widget.winfo_rootx() + 20
+            y = self.widget.winfo_rooty() + self.widget.winfo_height() + 8
+        except Exception:
+            return
+        self._tip = tip = tk.Toplevel(self.widget)
+        tip.wm_overrideredirect(True)
+        tip.wm_geometry(f"+{x}+{y}")
+        label = tk.Label(
+            tip,
+            text=self.text,
+            justify="left",
+            background="#ffffe0",
+            foreground="#000000",
+            relief="solid",
+            borderwidth=1,
+            wraplength=self.wraplength,
+        )
+        label.pack(ipadx=4, ipady=3)
+
+    def _hide(self, _event=None):
+        self._cancel()
+        if self._tip is not None:
+            try:
+                self._tip.destroy()
+            except Exception:
+                pass
+            self._tip = None
+
+
+def _theme_path():
+    """Absolute path to nlp_suite_theme.json, or ``None`` if it can't be located.
+
+    Resolves through ``GUI_IO_util.scriptPath`` (which is frozen-bundle aware -- the theme ships to
+    ``<exe>/src`` via NLP_Suite.spec) and falls back to this module's own directory for a dev
+    checkout. Imported lazily so this module has no import-time dependency on GUI_IO_util (which the
+    unit-test harness stubs).
+    """
+    import os
+
+    candidates = []
+    try:
+        import GUI_IO_util
+
+        candidates.append(os.path.join(GUI_IO_util.scriptPath, "nlp_suite_theme.json"))
+    except Exception:
+        pass
+    candidates.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), "nlp_suite_theme.json"))
+    for path in candidates:
+        try:
+            if os.path.isfile(path):
+                return path
+        except Exception:
+            pass
+    return None
+
+
+_initialized = False
+
+
+def init_appearance(appearance_mode="system"):
+    """One-time, idempotent CustomTkinter bootstrap. Call once at startup, before creating any CTk
+    widget or CTkImage.
+
+    Order matters: the bundle ImageTk patch (``ctk_bundle_util.patch_ctk_image_for_bundle``) must
+    run before any CTkImage is built, and the color theme must be set before any widget is created
+    (CTk snapshots theme colors at construction). Falls back to CTk's stock ``blue`` theme if the
+    NLP Suite theme file can't be found or fails to load, so a bad/missing data file degrades
+    appearance instead of crashing the launch -- but the failure is printed, NOT swallowed silently,
+    because a silent fallback previously hid a malformed-theme bug (CTk rejects a top-level JSON key
+    whose value is not a dict, e.g. a ``"_comment"`` string) that shipped the whole suite in blue.
+    """
+    global _initialized
+    if _initialized:
+        return
+    ctk_bundle_util.patch_ctk_image_for_bundle()
+    path = _theme_path()
+    if path:
+        try:
+            ctk.set_default_color_theme(path)
+        except Exception as exc:
+            warnings.warn(
+                f"failed to load NLP Suite theme '{path}' ({exc}); falling back to the stock 'blue' theme.",
+                stacklevel=2,
+            )
+            ctk.set_default_color_theme("blue")
+    else:
+        warnings.warn("nlp_suite_theme.json not found; falling back to the stock 'blue' theme.", stacklevel=2)
+        ctk.set_default_color_theme("blue")
+    try:
+        ctk.set_appearance_mode(appearance_mode)
+    except Exception:
+        pass
+    _initialized = True

--- a/src/GUI_theme_util.py
+++ b/src/GUI_theme_util.py
@@ -209,8 +209,20 @@ def create_entry(master, **kwargs):
     return ctk.CTkEntry(master, **translate_kwargs(ctk.CTkEntry, kwargs, height_is_lines=False))
 
 
+# CTk's default checkbox box is 24x24 with a 3px border -- chunky next to the suite's 13pt label
+# font (the box out-measures the text's cap height, reading as oversized). Size the box to the text
+# instead: ~18px square with a 2px border tracks the 13pt glyphs. Set here (not the theme JSON, which
+# has no checkbox_width/height keys) as overridable defaults so a call site can still request its own.
+_CHECKBOX_BOX_PX = 18
+_CHECKBOX_BORDER_PX = 2
+
+
 def create_checkbox(master, **kwargs):
-    return ctk.CTkCheckBox(master, **translate_kwargs(ctk.CTkCheckBox, kwargs))
+    translated = translate_kwargs(ctk.CTkCheckBox, kwargs)
+    translated.setdefault("checkbox_width", _CHECKBOX_BOX_PX)
+    translated.setdefault("checkbox_height", _CHECKBOX_BOX_PX)
+    translated.setdefault("border_width", _CHECKBOX_BORDER_PX)
+    return ctk.CTkCheckBox(master, **translated)
 
 
 # Neutral grey for a "nothing available" OptionMenu (muted=True). The theme paints every menu solid

--- a/src/GUI_theme_util.py
+++ b/src/GUI_theme_util.py
@@ -132,7 +132,8 @@ def _accepted_params(cls):
     return {
         name
         for name, p in params.items()
-        if name not in ("self", "master", "args", "kwargs") and p.kind not in (p.VAR_POSITIONAL, p.VAR_KEYWORD)
+        if name not in ("self", "master", "args", "kwargs")
+        and p.kind not in (p.VAR_POSITIONAL, p.VAR_KEYWORD)
     }
 
 
@@ -182,7 +183,7 @@ def create_button(master, **kwargs):
 # these as ~8px empty slivers (the red bars / gray box users read as broken). A folder glyph plus a
 # real width makes them read as buttons. Kept in one place so the glyph can be swapped in a single
 # edit if a platform's Tk font renders emoji as a tofu box (fallback: '...').
-OPEN_FILE_GLYPH = '\U0001F4C2'  # 📂
+OPEN_FILE_GLYPH = "\U0001f4c2"  # 📂
 
 
 def create_open_file_button(master, command=None, width=32, **kwargs):
@@ -193,10 +194,10 @@ def create_open_file_button(master, command=None, width=32, **kwargs):
     ~30px icon button can't be expressed through it. Any leftover legacy ``text``/``width`` kwargs
     are dropped in favour of the fixed glyph and the pixel width.
     """
-    kwargs.pop('text', None)
-    kwargs.pop('width', None)
+    kwargs.pop("text", None)
+    kwargs.pop("width", None)
     translated = translate_kwargs(ctk.CTkButton, kwargs)
-    translated['width'] = width
+    translated["width"] = width
     return ctk.CTkButton(master, text=OPEN_FILE_GLYPH, command=command, **translated)
 
 
@@ -206,14 +207,16 @@ def create_label(master, **kwargs):
 
 def create_entry(master, **kwargs):
     # tk.Entry has no height; only width is character-based.
-    return ctk.CTkEntry(master, **translate_kwargs(ctk.CTkEntry, kwargs, height_is_lines=False))
+    return ctk.CTkEntry(
+        master, **translate_kwargs(ctk.CTkEntry, kwargs, height_is_lines=False)
+    )
 
 
 # CTk's default checkbox box is 24x24 with a 3px border -- chunky next to the suite's 13pt label
 # font (the box out-measures the text's cap height, reading as oversized). Size the box to the text
 # instead: ~18px square with a 2px border tracks the 13pt glyphs. Set here (not the theme JSON, which
 # has no checkbox_width/height keys) as overridable defaults so a call site can still request its own.
-_CHECKBOX_BOX_PX = 18
+_CHECKBOX_BOX_PX = 16
 _CHECKBOX_BORDER_PX = 2
 
 
@@ -235,7 +238,9 @@ _MUTED_BUTTON_HOVER = "#b4b4b4"
 _MUTED_TEXT = "#5f5f5f"
 
 
-def create_option_menu(master, variable=None, values=None, command=None, muted=False, **kwargs):
+def create_option_menu(
+    master, variable=None, values=None, command=None, muted=False, **kwargs
+):
     """tk.OptionMenu(master, var, *choices) -> CTkOptionMenu(master, variable=, values=[...]).
 
     The legacy call passes the choices as varargs; call sites converting to this factory pass them
@@ -268,7 +273,9 @@ def create_combobox(master, values=None, **kwargs):
     return ctk.CTkComboBox(master, **translated)
 
 
-def create_slider(master, from_=None, to=None, length=None, orient=None, resolution=None, **kwargs):
+def create_slider(
+    master, from_=None, to=None, length=None, orient=None, resolution=None, **kwargs
+):
     """tk.Scale(...) -> CTkSlider(...).
 
     Maps the tk names CTk renamed: ``length`` (px long dimension) -> ``width``, ``orient`` ->
@@ -276,7 +283,9 @@ def create_slider(master, from_=None, to=None, length=None, orient=None, resolut
     CTkSlider has no built-in value label; call sites that need one add a small CTkLabel bound to
     the same variable (the legacy ``slider_widget`` popup already does this by hand).
     """
-    translated = translate_kwargs(ctk.CTkSlider, kwargs, width_is_chars=False, height_is_lines=False)
+    translated = translate_kwargs(
+        ctk.CTkSlider, kwargs, width_is_chars=False, height_is_lines=False
+    )
     if from_ is not None:
         translated["from_"] = from_
     if to is not None:
@@ -400,7 +409,9 @@ def _theme_path():
         candidates.append(os.path.join(GUI_IO_util.scriptPath, "nlp_suite_theme.json"))
     except Exception:
         pass
-    candidates.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), "nlp_suite_theme.json"))
+    candidates.append(
+        os.path.join(os.path.dirname(os.path.abspath(__file__)), "nlp_suite_theme.json")
+    )
     for path in candidates:
         try:
             if os.path.isfile(path):
@@ -440,7 +451,10 @@ def init_appearance(appearance_mode="system"):
             )
             ctk.set_default_color_theme("blue")
     else:
-        warnings.warn("nlp_suite_theme.json not found; falling back to the stock 'blue' theme.", stacklevel=2)
+        warnings.warn(
+            "nlp_suite_theme.json not found; falling back to the stock 'blue' theme.",
+            stacklevel=2,
+        )
         ctk.set_default_color_theme("blue")
     try:
         ctk.set_appearance_mode(appearance_mode)

--- a/src/GUI_util.py
+++ b/src/GUI_util.py
@@ -1217,51 +1217,33 @@ def display_about_release_team_cite_buttons(scriptName):
             y_multiplier_integer = 1.7
         else:
             y_multiplier_integer = 0
-        # CTk migration (slice 2a): themed CTk buttons. foreground="red" is dropped -- the NLP Suite
-        # theme now paints these as red-filled buttons with light text (red-on-red otherwise).
-        about_button = GUI_theme_util.create_button(window, text='About', width=15, height=1,
-                                command=lambda: GUI_IO_util.about())
-        # place widget with hover-over info
-        y_multiplier_integer = GUI_IO_util.placeWidget(window,
-                                                       GUI_IO_util.about_button_x_coordinate,
-                                                       y_multiplier_integer,
-                                                       about_button,
-                                                       True, False, False, False, 90,
-                                                       GUI_IO_util.about_button_x_coordinate,
-                                                       "Click on the button to access the About page of the NLP Suite GitHub repository.\nYou must be connected to the internet.")
-
-        release_history_button = GUI_theme_util.create_button(window, text='Release history', width=15, height=1,
-                                           command=lambda: GUI_IO_util.release_history())
-        # place widget with hover-over info
-        y_multiplier_integer = GUI_IO_util.placeWidget(window,
-                                                       GUI_IO_util.release_history_button_x_coordinate,
-                                                       y_multiplier_integer,
-                                                       release_history_button,
-                                                       True, False, False, False, 90,
-                                                       GUI_IO_util.about_button_x_coordinate,
-                                                       "Click on the button to access the Release history page of the NLP Suite GitHub repository.\nYou must be connected to the internet.")
-
-        team_button = GUI_theme_util.create_button(window, text='NLP Suite team', width=15, height=1,
-                                command=lambda: GUI_IO_util.list_team())
-        # place widget with hover-over info
-        y_multiplier_integer = GUI_IO_util.placeWidget(window,
-                                                       GUI_IO_util.team_button_x_coordinate,
-                                                       y_multiplier_integer,
-                                                       team_button,
-                                                       True, False, False, False, 90,
-                                                       GUI_IO_util.release_history_button_x_coordinate,
-                                                       "Click on the button to access the Team page of the NLP Suite GitHub repository.\nYou must be connected to the internet.")
-
-        cite_button = GUI_theme_util.create_button(window, text='How to cite', width=15, height=1,
-                                command=lambda: GUI_IO_util.cite_NLP())
-        # place widget with hover-over info
-        y_multiplier_integer = GUI_IO_util.placeWidget(window,
-                                                       GUI_IO_util.cite_button_x_coordinate,
-                                                       y_multiplier_integer,
-                                                       cite_button,
-                                                       False, False, False, False, 90,
-                                                       GUI_IO_util.team_button_x_coordinate,
-                                                       "Click on the button to access the How to Cite page of the NLP Suite GitHub repository.\nYou must be connected to the internet.")
+        # CTk migration: themed CTk buttons, grouped in ONE frame pinned to the window's top-right
+        # with place() instead of gridded into four separate coarse-band columns. The gridded version
+        # spilled off the right edge -- the wide 95-char SETUP/info buttons stretch the middle grid
+        # columns, pushing "NLP Suite team" and "How to cite" past the window edge. place(anchor='ne')
+        # keeps the four nav buttons flush to the top-right regardless of the grid's content width, and
+        # takes them out of the grid so they no longer widen it. (foreground="red" is dropped -- the
+        # NLP Suite theme paints these as red-filled buttons with light text.)
+        nav_bar = tk.Frame(window)
+        _nav_specs = [
+            ('About', lambda: GUI_IO_util.about(),
+             "Click on the button to access the About page of the NLP Suite GitHub repository.\nYou must be connected to the internet."),
+            ('Release history', lambda: GUI_IO_util.release_history(),
+             "Click on the button to access the Release history page of the NLP Suite GitHub repository.\nYou must be connected to the internet."),
+            ('NLP Suite team', lambda: GUI_IO_util.list_team(),
+             "Click on the button to access the Team page of the NLP Suite GitHub repository.\nYou must be connected to the internet."),
+            ('How to cite', lambda: GUI_IO_util.cite_NLP(),
+             "Click on the button to access the How to Cite page of the NLP Suite GitHub repository.\nYou must be connected to the internet."),
+        ]
+        # 2x2 block, not a single wide row: a horizontal bar of all four (~700px) either overflows the
+        # right edge or overlaps the welcome text on the left. A compact 2x2 grid fits in the open
+        # top-right corner, clear of the welcome text and above the SETUP rows.
+        for _i, (_nav_text, _nav_cmd, _nav_tip) in enumerate(_nav_specs):
+            _nav_button = GUI_theme_util.create_button(nav_bar, text=_nav_text, width=15, height=1, command=_nav_cmd)
+            _nav_button.grid(row=_i // 2, column=_i % 2, padx=(0, 8), pady=(0, 6))
+            GUI_theme_util.ToolTip(_nav_button, _nav_tip)
+        # Pin to the top-right corner. y tracks the legacy row (welcome pushes it down one line).
+        nav_bar.place(relx=1.0, x=-20, y=int(46 + y_multiplier_integer * 40), anchor='ne')
 
 global IO_setup_config_SV
 IO_setup_config_SV = ''

--- a/src/GUI_util.py
+++ b/src/GUI_util.py
@@ -312,18 +312,31 @@ def display_logo():
         return  # PIL not installed; skip logo rather than exiting the whole app
 
     try:
-        from PIL import Image
+        from PIL import Image, ImageChops
         # https://stackoverflow.com/questions/17504570/creating-simply-image-gallery-in-python-tkinter-pil
         # https://stackoverflow.com/questions/76616042/attributeerror-module-pil-image-has-no-attribute-antialias
         image_list = [GUI_IO_util.image_libPath + os.sep + "logo.png"]
         for x in image_list:
-            img = tk_image_from_pil(Image.open(x).resize((58,34), Image.LANCZOS)) #Image.ANTIALIAS))
-            logo = tk.Label(window, width=58, height=34, anchor='nw', image=img)
+            src = Image.open(x)
+            # logo.png carries ~15% of its width as BUILT-IN left whitespace (plus top/bottom padding):
+            # the ink's bounding box is ~118..708 of a 767px-wide canvas. Resizing the whole canvas
+            # scaled that padding up too, so the logo rendered as a small mark floating to the RIGHT of
+            # the ? HELP buttons' left edge -- the "off-putting gap" / "logo too small" look. Crop to
+            # the ink first (trim the white margins), THEN size the trimmed mark. Now it sits flush at
+            # the column's left edge and actually fills the column. Trim is dynamic (getbbox against a
+            # white field) so it self-corrects if the asset is ever re-exported with different padding.
+            bg = Image.new("RGB", src.size, (255, 255, 255))
+            bbox = ImageChops.difference(src.convert("RGB"), bg).getbbox()
+            if bbox:
+                src = src.crop(bbox)
+            # Trimmed aspect ~1.82; 84x46 matches the ? HELP button width (~80px) with the buttons' left edge.
+            img = tk_image_from_pil(src.resize((84, 46), Image.LANCZOS)) #Image.ANTIALIAS))
+            logo = tk.Label(window, width=84, height=46, anchor='nw', image=img)
             logo.image = img
             # Left-align the logo with the ? HELP buttons. Under the grid layout those buttons sit at
             # column 0's left padding (~6px), NOT at the legacy help_button_x_coordinate pixel (~70) --
             # so the old `help_button_x_coordinate - 12` offset left the logo floating to their right.
-            # Place it at the same left edge instead (the image carries a little of its own whitespace).
+            # Place it at the same left edge instead (the mark is now cropped flush, no built-in margin).
             logo.place(x=4, y=10)
     except Exception:
         pass  # Logo is cosmetic; skip silently if PIL/ImageTk is unavailable or incompatible
@@ -449,11 +462,12 @@ def display_release():
     # (and shoving every other column right, feeding the horizontal sprawl on the right).
     release_display = 'Release\n' + str(release_version_var.get().replace('\n','')) + "/" + str(GitHub_newest_release)
     release_lb = tk.Label(window, text=release_display, foreground="red", font=('TkDefaultFont', 9), justify='left') #height=1,
-    # CTk migration slice 2b: the logo is .place'd in the top-left corner (y=10, ~50px tall); the
-    # release label belongs directly under it. Gridding it (via placeWidget) dropped it into the tall
-    # header row 0 where it rendered ON TOP OF the logo. .place it under the logo instead -- .place
-    # coexists with the grid, same as the logo -- so it sits under the logo regardless of grid metrics.
-    release_lb.place(x=10, y=48)
+    # CTk migration slice 2b: the logo is .place'd in the top-left corner (y=10, 46px tall, so it
+    # runs to ~y=56); the release label belongs directly under it. Gridding it (via placeWidget)
+    # dropped it into the tall header row 0 where it rendered ON TOP OF the logo. .place it under the
+    # logo instead -- .place coexists with the grid, same as the logo -- so it sits under the logo
+    # regardless of grid metrics. y=62 clears the taller logo's bottom edge.
+    release_lb.place(x=10, y=62)
     import GUI_theme_util
     GUI_theme_util.ToolTip(release_lb,
                            "The two sets of numbers, separated by /, refer to the NLP Suite release on your machine (left) and the release available on GitHub (right)\nWithout internet the newest release available on GitHub cannnot be retrieved and is displayed as 0.0.0.")

--- a/src/GUI_util.py
+++ b/src/GUI_util.py
@@ -568,6 +568,8 @@ def display_IO_setup(window,IO_setup_display_brief,config_filename, config_input
             return missing_IO
         date_hover_over_label, IO_setup_display_string, config_input_output_alphabetic_options, missing_IO = \
             set_IO_brief_values(config_filename,y_multiplier_integer)
+        if IO_setup_brief_display_area is not None:
+            update_display_area(IO_setup_display_string, IO_setup_brief_display_area)
     # the full options must always be displayed, even when the brief option is selected;
     #   the reason is that the IO widgets filename, inputDir, and outputDir are used in all GUIs
     return missing_IO
@@ -787,20 +789,9 @@ def set_IO_brief_values(config_filename, y_multiplier_integer):
     # IO_setup_display_string = IO_setup_display_string + "\nOUTPUT DIR: " + str(os.path.basename(os.path.normpath(config_input_output_alphabetic_options[3][1])))
     IO_setup_display_string = IO_setup_display_string + "\nOUTPUT DIR: " + str(os.path.basename(config_input_output_alphabetic_options[3][1]))
 
-    # re-lay the widget to display the correct hover-over info
-    IO_setup_brief_display_area = tk.Text(width=60, height=2)
-    # place widget with hover-over info
-    y_multiplier_integer=0
-    y_multiplier_integer = GUI_IO_util.placeWidget(window,
-                                                   GUI_IO_util.setup_IO_brief_coordinate,
-                                                   y_multiplier_integer,
-                                                   IO_setup_brief_display_area,
-                                                   False, False, False, False, 90,
-                                                   GUI_IO_util.setup_IO_brief_coordinate,
-                                                   date_hover_over_label)
-    update_display_area(IO_setup_display_string,IO_setup_brief_display_area)
-    # update_display_area(IO_setup_display_string)
-
+    # widget creation/placement lives in IO_config_setup_brief (the single INPUT/OUTPUT display
+    # box); this function only computes the values the caller (initial build or refresh path)
+    # displays in that box.
     return date_hover_over_label, IO_setup_display_string, config_input_output_alphabetic_options, missing_IO
 
 def open_paste_text_popup():
@@ -921,14 +912,12 @@ def IO_config_setup_brief(window, y_multiplier_integer, config_filename, scriptN
 
     # display text area for setup brief
 
+    date_hover_over_label = ''
+    IO_setup_display_string = ''
     if config_input_output_numeric_options!=[0,0,0,0]:
         date_hover_over_label, IO_setup_display_string, config_input_output_alphabetic_options, missing_IO = set_IO_brief_values(config_filename, y_multiplier_integer)
-    # TODO(ctk-migration): DUPLICATE INPUT display box. set_IO_brief_values() (called just above)
-    # already creates AND places its own tk.Text(width=60) box, then this creates a SECOND identical
-    # one -- two side-by-side INPUT FILE/DIR boxes render on every GUI, ~450px each, driving the
-    # right-side overflow. Fix: make set_IO_brief_values() compute-and-return only (no widget), keep
-    # this single box, and have the refresh path display_IO_setup() update this box instead of
-    # letting set_IO_brief_values() recreate one. Verify file/dir selection still refreshes the box.
+    # single INPUT/OUTPUT display box (values computed by set_IO_brief_values above; the refresh
+    # path display_IO_setup() updates this same widget instead of creating a new one)
     IO_setup_brief_display_area = tk.Text(width=60, height=2)
     # place widget with hover-over info
     y_multiplier_integer = GUI_IO_util.placeWidget(window,

--- a/src/GUI_util.py
+++ b/src/GUI_util.py
@@ -227,7 +227,15 @@ reminders_dropdown_field = tk.StringVar()
 setup_menu = tk.StringVar()
 data_tools_options_widget = tk.StringVar()
 
-run_button = GUI_theme_util.create_button(window, text='RUN', width=10,height=2)
+# CTk migration slice 2b: RUN and CLOSE live in their OWN frame (a bottom button bar), NOT in the
+# shared content grid. Grid columns are shared across rows, so wide content widgets (a long input-file
+# entry, the IO path displays) inflate the columns the bottom chrome sits in and push RUN/CLOSE off the
+# right edge -- they were invisible on every GUI. Packing them left-to-right in a dedicated frame makes
+# their position independent of content width, so they are always visible. run_button is created here
+# at import (mains bind its command before GUI_bottom runs, so it must stay the same object), which is
+# why its master is the frame from the start.
+run_close_bar = tk.Frame(window)
+run_button = GUI_theme_util.create_button(run_close_bar, text='RUN', width=10,height=2)
 
 # license agreement GUI
 agreement_checkbox_var=tk.IntVar()
@@ -1257,6 +1265,11 @@ def GUI_top(config_input_output_numeric_options,config_filename, IO_setup_displa
         # coexists with grid).
         intro.grid(row=0, column=1, columnspan=GUI_IO_util._GRID_TOTAL_COLUMNS,
                    padx=6, pady=(6, 4), sticky='w')
+        # Reserve column 0's width for the .place'd logo + release label (they sit at x~58 and run to
+        # ~x190). Without this, column 0 sizes only to the ? HELP buttons (~140px) and the intro text
+        # in column 1 starts under the logo/release -- the overlap the user saw. minsize pushes column
+        # 1 (and every content label) to start clear of the logo zone.
+        window.grid_columnconfigure(0, minsize=210)
         display_logo()
         # although the release version appears in the top part of the GUI,
         #   it is run at the end otherwise a message will be displayed with an incomplete GUI
@@ -1706,15 +1719,14 @@ def GUI_bottom(config_filename, config_input_output_numeric_options, y_multiplie
 
     # there is no RUN button when setting up IO information in any of the NLP_setup scripts
     #   or in any of the GUIs that are ALL options GUIs (except for narrative_analysis where we use checkboxes instead of buttons))
-    # TODO RUN button
-    if ('narrative_analysis' in scriptName) or (not "NLP_setup_" in scriptName \
-            and (not "ALL_main" in scriptName)):
-        # place widget with hover-over info
-        y_multiplier_integer = GUI_IO_util.placeWidget(window, GUI_IO_util.run_button_x_coordinate,
-                                                       y_multiplier_integer_SV,
-                                                       run_button, True, False, False, False, 90,
-                                                       GUI_IO_util.open_setup_x_coordinate,
-                                                       'Click on the button to run the algorithm(s) behind the selected option(s)')
+    # RUN/CLOSE go in the dedicated run_close_bar frame (see its creation note): pack them left-to-right
+    # so their position is independent of the wide content columns. The bar itself is gridded below.
+    show_run_button = ('narrative_analysis' in scriptName) or (not "NLP_setup_" in scriptName
+            and (not "ALL_main" in scriptName))
+    if show_run_button:
+        run_button.pack(in_=run_close_bar, side='left', padx=6, pady=2)
+        GUI_theme_util.ToolTip(run_button,
+                               'Click on the button to run the algorithm(s) behind the selected option(s)')
 
     # TODO CLOSE button
     def _close_window():
@@ -1733,14 +1745,19 @@ def GUI_bottom(config_filename, config_input_output_numeric_options, y_multiplie
 
     # do not display CLOSE button for the 3 NLP_setup GUIs; the CLOSE is handled in those GUIs
     if not "NLP_setup_" in scriptName:
-        close_button = GUI_theme_util.create_button(window, text='CLOSE', width=10,height=2, command=lambda: _close_window())
-        # place widget with hover-over info
-        y_multiplier_integer = GUI_IO_util.placeWidget(window, GUI_IO_util.close_button_x_coordinate,
-                                                       y_multiplier_integer,
-                                                       close_button, True, False, False, False, 90,
-                                                       GUI_IO_util.read_button_x_coordinate,
-                                                       "Pressing the CLOSE button will trigger the automatic update of the NLP Suite pulling the latest release from GitHub. The new release will be displayed next time you open your local NLP Suite."
-                                                       "\nYou must be connected to the internet for the auto update to work.")
+        close_button = GUI_theme_util.create_button(run_close_bar, text='CLOSE', width=10,height=2, command=lambda: _close_window())
+        close_button.pack(in_=run_close_bar, side='left', padx=6, pady=2)
+        GUI_theme_util.ToolTip(close_button,
+                               "Pressing the CLOSE button will trigger the automatic update of the NLP Suite pulling the latest release from GitHub. The new release will be displayed next time you open your local NLP Suite."
+                               "\nYou must be connected to the internet for the auto update to work.")
+
+    # .place the RUN/CLOSE bar at the window's bottom-RIGHT corner (right-aligned, as requested).
+    # It is .place'd rather than gridded on purpose: the content grid can be wider than the visible
+    # window (wide IO rows), so a gridded sticky='e' would pin RUN/CLOSE to the grid's right edge --
+    # off-screen. relx=1.0 anchors to the VISIBLE window's right edge instead, so RUN/CLOSE stay in
+    # the bottom-right corner at any window width. (.place coexists with grid, same as the logo.)
+    if show_run_button or (not "NLP_setup_" in scriptName):
+        run_close_bar.place(relx=1.0, rely=1.0, x=-12, y=-10, anchor='se')
 
     # Any message should be displayed after the whole GUI has been displayed
 
@@ -1822,7 +1839,9 @@ def GUI_bottom(config_filename, config_input_output_numeric_options, y_multiplie
                 conf_w, conf_h = 0, 0
             screen_w, screen_h = window.winfo_screenwidth(), window.winfo_screenheight()
             new_w = min(max(conf_w, window.winfo_reqwidth()), screen_w)
-            new_h = min(max(conf_h, window.winfo_reqheight()), screen_h - 80)
+            # +48 reserves a strip at the bottom for the .place'd RUN/CLOSE bar (it is not in the grid,
+            # so it does not count toward reqheight -- without the reserve it would overlap the chrome).
+            new_h = min(max(conf_h, window.winfo_reqheight() + 48), screen_h - 80)
             window.geometry(f"{new_w}x{new_h}")
             window.resizable(True, True)
         except Exception as _e:

--- a/src/GUI_util.py
+++ b/src/GUI_util.py
@@ -1784,6 +1784,11 @@ def GUI_bottom(config_filename, config_input_output_numeric_options, y_multiplie
                                "Pressing the CLOSE button will trigger the automatic update of the NLP Suite pulling the latest release from GitHub. The new release will be displayed next time you open your local NLP Suite."
                                "\nYou must be connected to the internet for the auto update to work.")
 
+    # Every widget is now placed, so let wide widgets span to the next occupied column on their row
+    # instead of inflating a column that every other row shares. Must run before the run_close_bar
+    # height is reserved below, since it changes how tall/wide the content grid ends up.
+    GUI_IO_util.apply_row_spans(window)
+
     # .place the RUN/CLOSE bar at the window's bottom-RIGHT corner (right-aligned, as requested).
     # It is .place'd rather than gridded on purpose: the content grid can be wider than the visible
     # window (wide IO rows), so a gridded sticky='e' would pin RUN/CLOSE to the grid's right edge --
@@ -1791,6 +1796,16 @@ def GUI_bottom(config_filename, config_input_output_numeric_options, y_multiplie
     # the bottom-right corner at any window width. (.place coexists with grid, same as the logo.)
     if show_run_button or (not "NLP_setup_" in scriptName):
         run_close_bar.place(relx=1.0, rely=1.0, x=-12, y=-10, anchor='se')
+
+        # A .place'd bar floats OVER the grid and reserves no space, so whenever the content grid
+        # grew tall enough to reach into the bottom strip, RUN/CLOSE sat on top of the last content
+        # row (the Setup/reminders row). Whether it collided depended on the window height, which is
+        # why it looked intermittent. Reserve a spacer row below the last content row, as tall as the
+        # bar, so grid content can never flow underneath it.
+        window.update_idletasks()
+        bar_height = run_close_bar.winfo_reqheight() + 20  # + the y=-10 offset and a little breathing room
+        spacer_row = window.grid_size()[1]
+        window.grid_rowconfigure(spacer_row, minsize=bar_height)
 
     # Any message should be displayed after the whole GUI has been displayed
 

--- a/src/GUI_util.py
+++ b/src/GUI_util.py
@@ -18,7 +18,19 @@ import IO_libraries_util
 #     sys.exit(0)
 
 import tkinter as tk
-window = tk.Tk()
+
+# CTk migration (docs/CustomTkinter-Migration-Plan.md, Phase 1): the shared root window becomes a
+# CustomTkinter root so the whole suite renders themed. init_appearance() MUST run first -- it
+# applies the Phase 0 bundle ImageTk patch and loads the NLP Suite color theme BEFORE any widget is
+# created (CTk snapshots theme colors at construction time). tk / ttk widgets still parent to this
+# root unchanged (CTk() is a tkinter.Tk subclass), so the rest of the migration proceeds
+# incrementally on top of this. Appearance is pinned to "light" for now: while the individual GUI
+# widgets are still plain tk/ttk, "system"/dark would render a jarring half-dark UI -- the
+# appearance-mode toggle lands once the widgets themselves are CTk (plan Phase 5).
+import customtkinter as ctk
+import GUI_theme_util
+GUI_theme_util.init_appearance("light")
+window = ctk.CTk()
 from sys import platform
 
 import os
@@ -178,7 +190,7 @@ config_input_output_alphabetic_options=[]
 setup_IO_menu_var = tk.StringVar()
 # https://stackoverflow.com/questions/42222626/tkinter-option-menu-widget-add-command-lambda-does-not-produce-expected-command
 ###
-setup_IO_menu = tk.OptionMenu(window, setup_IO_menu_var, 'Default I/O configuration', 'Select any I/O csv config file')
+setup_IO_menu = GUI_theme_util.create_option_menu(window, variable=setup_IO_menu_var, values=['Default I/O configuration', 'Select any I/O csv config file'])
 
 IO_setup_var = tk.StringVar()
 IO_setup_brief_display_area = None
@@ -215,7 +227,7 @@ reminders_dropdown_field = tk.StringVar()
 setup_menu = tk.StringVar()
 data_tools_options_widget = tk.StringVar()
 
-run_button = tk.Button(window, text='RUN', width=10,height=2)
+run_button = GUI_theme_util.create_button(window, text='RUN', width=10,height=2)
 
 # license agreement GUI
 agreement_checkbox_var=tk.IntVar()
@@ -817,7 +829,7 @@ def openConfigFile(config_filename):
 # this is the Setup INPUT/OUTPUT configuration
 def IO_config_setup_brief(window, y_multiplier_integer, config_filename, scriptName, silent):
     global IO_setup_brief_display_area
-    IO_setup_button = tk.Button(window, width=GUI_IO_util.select_file_directory_button_width, text='Setup INPUT/OUTPUT configuration',
+    IO_setup_button = GUI_theme_util.create_button(window, width=GUI_IO_util.select_file_directory_button_width, text='Setup INPUT/OUTPUT configuration',
                 command=lambda: setup_IO_configuration_options(True, scriptName, silent=True, open_setup_IO_GUI=True))
     # place widget with hover-over info
     y_multiplier_integer = GUI_IO_util.placeWidget(window, GUI_IO_util.labels_x_coordinate,
@@ -846,7 +858,10 @@ def IO_config_setup_brief(window, y_multiplier_integer, config_filename, scriptN
     # else:
     #     config_filename = config_filename_selected_config.get()
     # setup button to open a pop-up text entry widget where users can paste text to be used instead of an input file
-    openTextWidget_button = tk.Button(window, width=GUI_IO_util.open_file_directory_button_width, text='',
+    # Give this its own width + label: it was an empty width=1 button (~8px under CTk, a thin red
+    # sliver) even though it opens a paste-text popup for a quick test run -- unlike the adjacent
+    # open_file_directory buttons, it has no neighbouring field to give it context.
+    openTextWidget_button = GUI_theme_util.create_button(window, width=12, text='Paste text',
                                       command=open_paste_text_popup)
     # place widget with hover-over info
     y_multiplier_integer = GUI_IO_util.placeWidget(window,GUI_IO_util.setup_pop_up_text_widget, y_multiplier_integer,
@@ -871,28 +886,28 @@ def IO_config_setup_brief(window, y_multiplier_integer, config_filename, scriptN
     # setup buttons to open an input file, an input directory, an output directory, and a csv config file
     x_coordinate_hover_over = GUI_IO_util.IO_configuration_menu+GUI_IO_util.open_file_button_brief
     # setup a button to open an input file
-    openInputFile_button = tk.Button(window, width=GUI_IO_util.open_file_directory_button_width, text='',
+    openInputFile_button = GUI_theme_util.create_open_file_button(window,
                                      command=lambda:IO_files_util.open_file_removing_date_from_filename(window,inputFilename.get(),True))
     # place widget with hover-over info
     y_multiplier_integer = GUI_IO_util.placeWidget(window,GUI_IO_util.IO_configuration_menu+GUI_IO_util.open_file_button_brief, y_multiplier_integer,
                                                    openInputFile_button, True, False, True, False, 90, x_coordinate_hover_over, "Open INPUT file")
 
     # setup a button to open Windows Explorer on the selected INPUT directory
-    openInputDirectory_button = tk.Button(window, width=GUI_IO_util.open_file_directory_button_width, text='',
+    openInputDirectory_button = GUI_theme_util.create_open_file_button(window,
                                      command=lambda: IO_files_util.open_directory_removing_date_from_directory(window,input_main_dir_path.get(),True))
     # place widget with hover-over info
     y_multiplier_integer = GUI_IO_util.placeWidget(window,GUI_IO_util.IO_configuration_menu+GUI_IO_util.open_inputDir_button_brief, y_multiplier_integer,
                                                    openInputDirectory_button, True, False, True,False, 90, x_coordinate_hover_over, "Open INPUT files directory")
 
     # setup a button to open Windows Explorer on the selected OUTPUT directory
-    openOutputDirectory_button = tk.Button(window, width=GUI_IO_util.open_file_directory_button_width, text='',
+    openOutputDirectory_button = GUI_theme_util.create_open_file_button(window,
                                      command=lambda: IO_files_util.openExplorer(window, output_dir_path.get()))
     # place widget with hover-over info
     y_multiplier_integer = GUI_IO_util.placeWidget(window,GUI_IO_util.IO_configuration_menu+GUI_IO_util.open_outputDir_button_brief, y_multiplier_integer,
                                                    openOutputDirectory_button, True, False, True,False, 90, x_coordinate_hover_over, "Open OUTPUT files directory")
 
     # Open csv config file
-    openInputConfigFile_button = tk.Button(window, width=GUI_IO_util.open_file_directory_button_width, text='',
+    openInputConfigFile_button = GUI_theme_util.create_open_file_button(window,
                                      command=lambda: openConfigFile(config_filename_selected_config.get()))
     # place widget with hover-over info
     y_multiplier_integer = GUI_IO_util.placeWidget(window,GUI_IO_util.IO_configuration_menu+GUI_IO_util.open_config_file_button_brief, y_multiplier_integer,
@@ -920,28 +935,28 @@ def IO_config_setup_full (window, y_multiplier_integer):
         # buttons are set to normal or disabled in selectFile_set_options
         if config_input_output_numeric_options[0]==1: #single CoNLL file
             # buttons are set to normal or disabled in selectFile_set_options
-            select_inputFilename_button=tk.Button(window, width=GUI_IO_util.select_file_directory_button_width, text='Select INPUT CoNLL table', command=lambda: selectFile_set_options(window,True,True,inputFilename,input_main_dir_path,'Select INPUT CoNLL table (csv file)',[('CoNLL csv file','.csv')],".csv"))
+            select_inputFilename_button=GUI_theme_util.create_button(window, width=GUI_IO_util.select_file_directory_button_width, text='Select INPUT CoNLL table', command=lambda: selectFile_set_options(window,True,True,inputFilename,input_main_dir_path,'Select INPUT CoNLL table (csv file)',[('CoNLL csv file','.csv')],".csv"))
         elif config_input_output_numeric_options[0]==2: #single txt file:
             # buttons are set to normal or disabled in selectFile_set_options
-            select_inputFilename_button=tk.Button(window, width=GUI_IO_util.select_file_directory_button_width, text='Select INPUT TXT file', command=lambda: selectFile_set_options(window,True,False,inputFilename,input_main_dir_path,'Select INPUT TXT file',[('text file','.txt')],".txt"))
+            select_inputFilename_button=GUI_theme_util.create_button(window, width=GUI_IO_util.select_file_directory_button_width, text='Select INPUT TXT file', command=lambda: selectFile_set_options(window,True,False,inputFilename,input_main_dir_path,'Select INPUT TXT file',[('text file','.txt')],".txt"))
         elif config_input_output_numeric_options[0]==3: #single csv file:
             # buttons are set to normal or disabled in selectFile_set_options
-            select_inputFilename_button=tk.Button(window, width=GUI_IO_util.select_file_directory_button_width, text='Select INPUT csv file', command=lambda: selectFile_set_options(window,True,False,inputFilename,input_main_dir_path,'Select INPUT csv file',[('csv file','.csv')],".csv"))
+            select_inputFilename_button=GUI_theme_util.create_button(window, width=GUI_IO_util.select_file_directory_button_width, text='Select INPUT csv file', command=lambda: selectFile_set_options(window,True,False,inputFilename,input_main_dir_path,'Select INPUT csv file',[('csv file','.csv')],".csv"))
         if config_input_output_numeric_options[0]==4: #any type file (used in NLP.py)
             # buttons are set to normal or disabled in selectFile_set_options
-            select_inputFilename_button=tk.Button(window, width=GUI_IO_util.select_file_directory_button_width, text='Select INPUT file (any type)', command=lambda: selectFile_set_options(window,True,False,inputFilename,input_main_dir_path,'Select INPUT file (any file type: pdf, docx, html, txt, csv, conll); switch extension type below near File name:',[("txt file","*.txt"),("csv file","*.csv"),("pdf file","*.pdf"),("docx file","*.docx"),("rtf file","*.rtf"),("html file","*.html"),("CoNLL table","*.conll")], "*.*"))
+            select_inputFilename_button=GUI_theme_util.create_button(window, width=GUI_IO_util.select_file_directory_button_width, text='Select INPUT file (any type)', command=lambda: selectFile_set_options(window,True,False,inputFilename,input_main_dir_path,'Select INPUT file (any file type: pdf, docx, html, txt, csv, conll); switch extension type below near File name:',[("txt file","*.txt"),("csv file","*.csv"),("pdf file","*.pdf"),("docx file","*.docx"),("rtf file","*.rtf"),("html file","*.html"),("CoNLL table","*.conll")], "*.*"))
         if config_input_output_numeric_options[0]==5: #txt/html
             # buttons are set to normal or disabled in selectFile_set_options
-            select_inputFilename_button=tk.Button(window, width=GUI_IO_util.select_file_directory_button_width, text='Select INPUT file (txt, html)', command=lambda: selectFile_set_options(window,True,False,inputFilename,input_main_dir_path,'Select INPUT file (txt, html); switch extension type below near File name:',[("txt file","*.txt"),("html file","*.html")], "*.*"))
+            select_inputFilename_button=GUI_theme_util.create_button(window, width=GUI_IO_util.select_file_directory_button_width, text='Select INPUT file (txt, html)', command=lambda: selectFile_set_options(window,True,False,inputFilename,input_main_dir_path,'Select INPUT file (txt, html); switch extension type below near File name:',[("txt file","*.txt"),("html file","*.html")], "*.*"))
         if config_input_output_numeric_options[0]==6: #txt/csv
             # buttons are set to normal or disabled in selectFile_set_options
-            select_inputFilename_button=tk.Button(window, width=GUI_IO_util.select_file_directory_button_width, text='Select INPUT file (txt, csv)', command=lambda: selectFile_set_options(window,True,False,inputFilename,input_main_dir_path,'Select INPUT file (txt, csv); switch extension type below near File name:',[("txt file","*.txt"),("csv file","*.csv")], "*.*"))
+            select_inputFilename_button=GUI_theme_util.create_button(window, width=GUI_IO_util.select_file_directory_button_width, text='Select INPUT file (txt, csv)', command=lambda: selectFile_set_options(window,True,False,inputFilename,input_main_dir_path,'Select INPUT file (txt, csv); switch extension type below near File name:',[("txt file","*.txt"),("csv file","*.csv")], "*.*"))
 
         # place the Select INPUT file widget
         y_multiplier_integer = GUI_IO_util.placeWidget(window,GUI_IO_util.labels_x_coordinate,y_multiplier_integer,select_inputFilename_button,True)
 
         #setup a button to open Windows Explorer on the selected input file
-        openInputFile_button  = tk.Button(window, width=GUI_IO_util.open_file_directory_button_width, text='',
+        openInputFile_button  = GUI_theme_util.create_open_file_button(window,
                             command=lambda: IO_files_util.open_file_removing_date_from_filename(window,inputFilename.get(),True))
         y_multiplier_integer = GUI_IO_util.placeWidget(window,
             GUI_IO_util.IO_configuration_menu, y_multiplier_integer,
@@ -964,14 +979,14 @@ def IO_config_setup_full (window, y_multiplier_integer):
     #primary INPUT directory ______________________________________________
     if config_input_output_numeric_options[1]==1: # main directory input
         # buttons are set to normal or disabled in selectFile_set_options
-        select_input_main_dir_button = tk.Button(window, width=GUI_IO_util.select_file_directory_button_width,
+        select_input_main_dir_button = GUI_theme_util.create_button(window, width=GUI_IO_util.select_file_directory_button_width,
             text='Select INPUT files directory',  command = lambda: selectDirectory_set_options(window,input_main_dir_path,output_dir_path,"Select INPUT files directory",True))
         # select_input_main_dir_button.config(state="normal")
         y_multiplier_integer = GUI_IO_util.placeWidget(window,GUI_IO_util.labels_x_coordinate,y_multiplier_integer,select_input_main_dir_button,True)
 
         #setup a button to open Windows Explorer on the selected main input directory
-        openDirectory_button  = tk.Button(window, width=GUI_IO_util.open_file_directory_button_width,
-                            text='', command=lambda: IO_files_util.open_directory_removing_date_from_directory(window,input_main_dir_path.get(),True))
+        openDirectory_button  = GUI_theme_util.create_open_file_button(window,
+                            command=lambda: IO_files_util.open_directory_removing_date_from_directory(window,input_main_dir_path.get(),True))
         y_multiplier_integer = GUI_IO_util.placeWidget(window,
             GUI_IO_util.IO_configuration_menu,
             y_multiplier_integer,
@@ -994,12 +1009,12 @@ def IO_config_setup_full (window, y_multiplier_integer):
     #secondary INPUT directory ______________________________________________
     if config_input_output_numeric_options[2]==1: #secondary directory input
         # buttons are set to normal or disabled in selectFile_set_options
-        select_input_secondary_dir_button = tk.Button(window, width=GUI_IO_util.select_file_directory_button_width, text='Select INPUT secondary directory',  command=lambda: selectDirectory_set_options(window,input_main_dir_path, input_secondary_dir_path,"Select INPUT secondary TXT directory"))
+        select_input_secondary_dir_button = GUI_theme_util.create_button(window, width=GUI_IO_util.select_file_directory_button_width, text='Select INPUT secondary directory',  command=lambda: selectDirectory_set_options(window,input_main_dir_path, input_secondary_dir_path,"Select INPUT secondary TXT directory"))
         y_multiplier_integer=GUI_IO_util.placeWidget(window,GUI_IO_util.labels_x_coordinate,
                             y_multiplier_integer,select_input_secondary_dir_button,True)
 
         #setup a button to open Windows Explorer on the selected secondary input directory
-        openDirectory_button  = tk.Button(window, width=GUI_IO_util.open_file_directory_button_width, text='', command=lambda: IO_files_util.openExplorer(window, input_secondary_dir_path.get()))
+        openDirectory_button  = GUI_theme_util.create_open_file_button(window, command=lambda: IO_files_util.openExplorer(window, input_secondary_dir_path.get()))
         y_multiplier_integer = GUI_IO_util.placeWidget(window,
             GUI_IO_util.IO_configuration_menu,
             y_multiplier_integer,
@@ -1012,12 +1027,12 @@ def IO_config_setup_full (window, y_multiplier_integer):
     #OUTPUT directory ______________________________________________
     if config_input_output_numeric_options[3]==1: #output directory
         # buttons are set to normal or disabled in selectFile_set_options
-        select_output_dir_button = tk.Button(window, width=GUI_IO_util.select_file_directory_button_width, text='Select OUTPUT files directory',  command=lambda: selectDirectory_set_options(window,input_main_dir_path,output_dir_path,"Select OUTPUT files directory"))
+        select_output_dir_button = GUI_theme_util.create_button(window, width=GUI_IO_util.select_file_directory_button_width, text='Select OUTPUT files directory',  command=lambda: selectDirectory_set_options(window,input_main_dir_path,output_dir_path,"Select OUTPUT files directory"))
         y_multiplier_integer=GUI_IO_util.placeWidget(window,GUI_IO_util.labels_x_coordinate,y_multiplier_integer,select_output_dir_button,True)
 
         #setup a button to open Windows Explorer on the selected input directory
         # current_y_multiplier_integer4=y_multiplier_integer-1
-        openDirectory_button  = tk.Button(window, width=GUI_IO_util.open_file_directory_button_width, text='', command=lambda: IO_files_util.openExplorer(window, output_dir_path.get()))
+        openDirectory_button  = GUI_theme_util.create_open_file_button(window, command=lambda: IO_files_util.openExplorer(window, output_dir_path.get()))
         y_multiplier_integer = GUI_IO_util.placeWidget(window,
             GUI_IO_util.IO_configuration_menu,
             y_multiplier_integer,
@@ -1157,7 +1172,9 @@ def display_about_release_team_cite_buttons(scriptName):
             y_multiplier_integer = 1.7
         else:
             y_multiplier_integer = 0
-        about_button = tk.Button(window, text='About', width=15, height=1, foreground="red",
+        # CTk migration (slice 2a): themed CTk buttons. foreground="red" is dropped -- the NLP Suite
+        # theme now paints these as red-filled buttons with light text (red-on-red otherwise).
+        about_button = GUI_theme_util.create_button(window, text='About', width=15, height=1,
                                 command=lambda: GUI_IO_util.about())
         # place widget with hover-over info
         y_multiplier_integer = GUI_IO_util.placeWidget(window,
@@ -1168,7 +1185,7 @@ def display_about_release_team_cite_buttons(scriptName):
                                                        GUI_IO_util.about_button_x_coordinate,
                                                        "Click on the button to access the About page of the NLP Suite GitHub repository.\nYou must be connected to the internet.")
 
-        release_history_button = tk.Button(window, text='Release history', width=15, height=1, foreground='red',
+        release_history_button = GUI_theme_util.create_button(window, text='Release history', width=15, height=1,
                                            command=lambda: GUI_IO_util.release_history())
         # place widget with hover-over info
         y_multiplier_integer = GUI_IO_util.placeWidget(window,
@@ -1179,7 +1196,7 @@ def display_about_release_team_cite_buttons(scriptName):
                                                        GUI_IO_util.about_button_x_coordinate,
                                                        "Click on the button to access the Release history page of the NLP Suite GitHub repository.\nYou must be connected to the internet.")
 
-        team_button = tk.Button(window, text='NLP Suite team', width=15, height=1, foreground="red",
+        team_button = GUI_theme_util.create_button(window, text='NLP Suite team', width=15, height=1,
                                 command=lambda: GUI_IO_util.list_team())
         # place widget with hover-over info
         y_multiplier_integer = GUI_IO_util.placeWidget(window,
@@ -1190,7 +1207,7 @@ def display_about_release_team_cite_buttons(scriptName):
                                                        GUI_IO_util.release_history_button_x_coordinate,
                                                        "Click on the button to access the Team page of the NLP Suite GitHub repository.\nYou must be connected to the internet.")
 
-        cite_button = tk.Button(window, text='How to cite', width=15, height=1, foreground="red",
+        cite_button = GUI_theme_util.create_button(window, text='How to cite', width=15, height=1,
                                 command=lambda: GUI_IO_util.cite_NLP())
         # place widget with hover-over info
         y_multiplier_integer = GUI_IO_util.placeWidget(window,
@@ -1313,8 +1330,8 @@ def display_setup_hover_over(y_multiplier_integer):
     hover_over_x_coordinate, hover_over_info = get_hover_over_info(package_display_area_value)
 
     # lay the setup widget
-    setup_menu_lb = tk.OptionMenu(window, setup_menu, "Setup preferences", "Setup NLP package (parsers & annotators) and corpus language",
-                                  "Setup external software")
+    setup_menu_lb = GUI_theme_util.create_option_menu(window, variable=setup_menu, values=["Setup preferences", "Setup NLP package (parsers & annotators) and corpus language",
+                                  "Setup external software"])
 
     if y_multiplier_integer_SV == 0:
         y_multiplier_integer_SV = y_multiplier_integer
@@ -1451,7 +1468,7 @@ def GUI_bottom(config_filename, config_input_output_numeric_options, y_multiplie
             not 'NLP_menu_main' in scriptName and \
             not "NLP_setup_" in scriptName:
         #open output csv files widget defined above since it is used earlier
-        open_csv_output_label = tk.Checkbutton(window, variable=open_csv_output_checkbox, onvalue=1, offvalue=0, command=lambda: trace_checkbox(open_csv_output_label, open_csv_output_checkbox, "Open output files", "Do NOT open output files"))
+        open_csv_output_label = GUI_theme_util.create_checkbox(window, variable=open_csv_output_checkbox, onvalue=1, offvalue=0, command=lambda: trace_checkbox(open_csv_output_label, open_csv_output_checkbox, "Open output files", "Do NOT open output files"))
         open_csv_output_label.configure(text="Open output files")
         y_multiplier_integer = GUI_IO_util.placeWidget(window,GUI_IO_util.labels_x_coordinate,
                                                        y_multiplier_integer,
@@ -1477,7 +1494,7 @@ def GUI_bottom(config_filename, config_input_output_numeric_options, y_multiplie
         charts_package_options = ['No charts','Excel','Python Plotly (dynamic)','Python Plotly (static)']
         # TODO EXCEL widget (same as open reminders)
         charts_package_options_widget.set('Excel')
-        charts_package_menu_lb = tk.OptionMenu(window,charts_package_options_widget,*charts_package_options)
+        charts_package_menu_lb = GUI_theme_util.create_option_menu(window, variable=charts_package_options_widget, values=charts_package_options)
         y_multiplier_integer = GUI_IO_util.placeWidget(window,GUI_IO_util.open_TIPS_x_coordinate,
                                                        y_multiplier_integer,
                                                        charts_package_menu_lb,
@@ -1495,7 +1512,7 @@ def GUI_bottom(config_filename, config_input_output_numeric_options, y_multiplie
                                    'Comparative bar charts (Open GUI)', 'Geographic maps (Open GUI)', 'Gephi (Open GUI)', 'Sankey flowchart (Open GUI)', 'Sunburst chart (Open GUI)',
                                    'Time mapper (Open GUI)', 'Treemap chart (Open GUI)', 'Wordcloud (Open GUI)']
         charts_type_options_widget.set('Bar chart')
-        charts_type_menu_lb = tk.OptionMenu(window,charts_type_options_widget,*charts_type_options)
+        charts_type_menu_lb = GUI_theme_util.create_option_menu(window, variable=charts_type_options_widget, values=charts_type_options)
         # place widget with hover-over info
         y_multiplier_integer = GUI_IO_util.placeWidget(window,GUI_IO_util.open_reminders_x_coordinate,
                                                        y_multiplier_integer,
@@ -1506,7 +1523,7 @@ def GUI_bottom(config_filename, config_input_output_numeric_options, y_multiplie
 
         data_transformation_options=['No transformation','Normalize by document size', 'Ln','Log','Square rooot','Z score']
         data_transformation_options_widget.set('No transformation')
-        data_transformation_menu_lb = tk.OptionMenu(window,data_transformation_options_widget,*data_transformation_options)
+        data_transformation_menu_lb = GUI_theme_util.create_option_menu(window, variable=data_transformation_options_widget, values=data_transformation_options)
         # place widget with hover-over info
         y_multiplier_integer = GUI_IO_util.placeWidget(window,GUI_IO_util.open_setup_x_coordinate,
                                                        y_multiplier_integer,
@@ -1532,7 +1549,7 @@ def GUI_bottom(config_filename, config_input_output_numeric_options, y_multiplie
         # if not 'data_manipulation_main.py' in scriptName and not 'data_visualization_1_main.py' in scriptName :
         data_tools_options = ['Data/corpus sampling', 'Data manipulation', 'Data statistics', 'Data visualization']
         data_tools_options_widget.set('Data tools')
-        data_tools_menu_lb = tk.OptionMenu(window, data_tools_options_widget, *data_tools_options)
+        data_tools_menu_lb = GUI_theme_util.create_option_menu(window, variable=data_tools_options_widget, values=data_tools_options)
         # place widget with hover-over info
         y_multiplier_integer = GUI_IO_util.placeWidget(window, GUI_IO_util.run_button_x_coordinate,
                                                        y_multiplier_integer,
@@ -1560,7 +1577,7 @@ def GUI_bottom(config_filename, config_input_output_numeric_options, y_multiplie
     #         charts_package_options_widget.set('Plotly')
     # charts_package_options_widget.trace('w',warning_message)
 
-    readme_button = tk.Button(window, text='Read Me',command=readMe_command,width=10,height=2)
+    readme_button = GUI_theme_util.create_button(window, text='Read Me',command=readMe_command,width=10,height=2)
     # In NLP_setup_IO_main and NLP_setup_package_language_main an extra line of widgets is added to the GUI
     # if "NLP_setup_IO_main" in scriptName:
     #     y_multiplier_integer = y_multiplier_integer +1
@@ -1577,13 +1594,12 @@ def GUI_bottom(config_filename, config_input_output_numeric_options, y_multiplie
     videos_dropdown_field.set('Watch videos')
     if len(videos_lookup)==1:
         if videos_options == "No videos available":
-            videos_menu_lb = tk.OptionMenu(window, videos_dropdown_field, videos_options)
+            # muted=True -> grey: no videos for this GUI (restores the legacy red=available cue)
+            videos_menu_lb = GUI_theme_util.create_option_menu(window, variable=videos_dropdown_field, values=[videos_options], muted=True)
         else:
-            videos_menu_lb = tk.OptionMenu(window, videos_dropdown_field, videos_options)
-            videos_menu_lb.configure(foreground="red")
+            videos_menu_lb = GUI_theme_util.create_option_menu(window, variable=videos_dropdown_field, values=[videos_options])
     else:
-        videos_menu_lb = tk.OptionMenu(window,videos_dropdown_field,*videos_options)
-        videos_menu_lb.configure(foreground="red")
+        videos_menu_lb = GUI_theme_util.create_option_menu(window, variable=videos_dropdown_field, values=videos_options)
     # place widget with hover-over info
     y_multiplier_integer = GUI_IO_util.placeWidget(window, GUI_IO_util.watch_videos_x_coordinate,
                                                    y_multiplier_integer,
@@ -1602,13 +1618,12 @@ def GUI_bottom(config_filename, config_input_output_numeric_options, y_multiplie
     tips_dropdown_field.set('Open TIPS files')
     if len(TIPS_lookup)==1:
         if TIPS_options == "No TIPS available":
-            tips_menu_lb = tk.OptionMenu(window, tips_dropdown_field, TIPS_options)
+            # muted=True -> grey: no TIPS for this GUI (restores the legacy red=available cue)
+            tips_menu_lb = GUI_theme_util.create_option_menu(window, variable=tips_dropdown_field, values=[TIPS_options], muted=True)
         else:
-            tips_menu_lb = tk.OptionMenu(window, tips_dropdown_field, TIPS_options)
-            tips_menu_lb.configure(foreground="red")
+            tips_menu_lb = GUI_theme_util.create_option_menu(window, variable=tips_dropdown_field, values=[TIPS_options])
     else:
-        tips_menu_lb = tk.OptionMenu(window,tips_dropdown_field,*TIPS_options)
-        tips_menu_lb.configure(foreground="red")
+        tips_menu_lb = GUI_theme_util.create_option_menu(window, variable=tips_dropdown_field, values=TIPS_options)
     # place widget with hover-over info
     y_multiplier_integer = GUI_IO_util.placeWidget(window, GUI_IO_util.open_TIPS_x_coordinate,
                                                    y_multiplier_integer,
@@ -1638,19 +1653,18 @@ def GUI_bottom(config_filename, config_input_output_numeric_options, y_multiplie
     # reminders content for specific GUIs are set in the csv file reminders
     # called from any GUI
     reminders_dropdown_field.set('Open reminders')
-    reminders_menu_lb = tk.OptionMenu(window,  reminders_dropdown_field,"No Reminders available")
+    reminders_menu_lb = GUI_theme_util.create_option_menu(window, variable=reminders_dropdown_field, values=["No Reminders available"], muted=True)
 
     if len(reminder_options)==0:
         reminder_options = ["No Reminders available"]
     if len(reminder_options)==0 or len(reminder_options)==1:
         if reminder_options == ["No Reminders available"]:
-            reminders_menu_lb = tk.OptionMenu(window, reminders_dropdown_field, *reminder_options)
+            # muted=True -> grey: no reminders for this GUI (restores the legacy red=available cue)
+            reminders_menu_lb = GUI_theme_util.create_option_menu(window, variable=reminders_dropdown_field, values=reminder_options, muted=True)
         else:
-            reminders_menu_lb = tk.OptionMenu(window, reminders_dropdown_field, *reminder_options)
-            reminders_menu_lb.configure(foreground="red")
+            reminders_menu_lb = GUI_theme_util.create_option_menu(window, variable=reminders_dropdown_field, values=reminder_options)
     else:
-        reminders_menu_lb = tk.OptionMenu(window,reminders_dropdown_field,*reminder_options)
-        reminders_menu_lb.configure(foreground="red")
+        reminders_menu_lb = GUI_theme_util.create_option_menu(window, variable=reminders_dropdown_field, values=reminder_options)
     # place widget with hover-over info
     y_multiplier_integer = GUI_IO_util.placeWidget(window, GUI_IO_util.open_reminders_x_coordinate,
                                                    y_multiplier_integer,
@@ -1704,7 +1718,7 @@ def GUI_bottom(config_filename, config_input_output_numeric_options, y_multiplie
 
     # do not display CLOSE button for the 3 NLP_setup GUIs; the CLOSE is handled in those GUIs
     if not "NLP_setup_" in scriptName:
-        close_button = tk.Button(window, text='CLOSE', width=10,height=2, command=lambda: _close_window())
+        close_button = GUI_theme_util.create_button(window, text='CLOSE', width=10,height=2, command=lambda: _close_window())
         # place widget with hover-over info
         y_multiplier_integer = GUI_IO_util.placeWidget(window, GUI_IO_util.close_button_x_coordinate,
                                                        y_multiplier_integer,

--- a/src/GUI_util.py
+++ b/src/GUI_util.py
@@ -466,8 +466,11 @@ def display_release():
     # runs to ~y=56); the release label belongs directly under it. Gridding it (via placeWidget)
     # dropped it into the tall header row 0 where it rendered ON TOP OF the logo. .place it under the
     # logo instead -- .place coexists with the grid, same as the logo -- so it sits under the logo
-    # regardless of grid metrics. y=62 clears the taller logo's bottom edge.
-    release_lb.place(x=10, y=62)
+    # regardless of grid metrics. The logo is a two-line "NLP / Suite" mark whose ink runs to the
+    # label's bottom edge (~y=56); y=62 left only ~6px, so the red "Release" line read as touching
+    # the logo. y=72 gives a clear gap below the logo (10 + 46 + 16) while staying well above the
+    # first ? HELP button row.
+    release_lb.place(x=10, y=72)
     import GUI_theme_util
     GUI_theme_util.ToolTip(release_lb,
                            "The two sets of numbers, separated by /, refer to the NLP Suite release on your machine (left) and the release available on GitHub (right)\nWithout internet the newest release available on GitHub cannnot be retrieved and is displayed as 0.0.0.")

--- a/src/GUI_util.py
+++ b/src/GUI_util.py
@@ -1293,6 +1293,16 @@ def GUI_top(config_input_output_numeric_options,config_filename, IO_setup_displa
         # logo/release -- the overlap the user saw. minsize pushes column 1 (and every content label)
         # just clear of the logo zone, keeping the left column as tight as the logo allows.
         window.grid_columnconfigure(0, minsize=122)
+        # Give every coarse band column (1..N, the bands defined by _GRID_COLUMN_THRESHOLDS) a
+        # minimum width so the layout reads as regular, evenly spaced columns. Without this, a band
+        # left empty on a given row (e.g. band 3 between a Value/Group column pair) collapses to zero
+        # width under grid, shoving the two label/control pairs flush against each other in the middle
+        # while the right side sits empty -- the "squished columns" look. A per-band floor keeps the
+        # bands apart on every row regardless of which are populated. RUN/CLOSE are .place'd in their
+        # own bottom bar now, so widening the grid bands can't push them off-screen.
+        _band_count = len(GUI_IO_util._GRID_COLUMN_THRESHOLDS) + 1  # thresholds -> one more band
+        for _band in range(1, _band_count):
+            window.grid_columnconfigure(_band, minsize=150)
         display_logo()
         # although the release version appears in the top part of the GUI,
         #   it is run at the end otherwise a message will be displayed with an incomplete GUI

--- a/src/GUI_util.py
+++ b/src/GUI_util.py
@@ -1238,6 +1238,10 @@ def GUI_top(config_input_output_numeric_options,config_filename, IO_setup_displa
     global select_inputFilename_button, select_input_main_dir_button, select_input_secondary_dir_button, select_output_dir_button
     # global config_input_output_alphabetic_options
 
+    # Fresh grid: clear the per-row column bookkeeping so this GUI's placeWidget calls start from an
+    # empty layout (state must not leak from any earlier build in the same process).
+    GUI_IO_util._reset_grid_layout()
+
     # No top help lines displayed when opening the license agreement GUI
     if config_filename!='license_config.csv':
         # wraplength keeps the multi-line intro from blowing out the grid width (without it the very
@@ -1249,7 +1253,7 @@ def GUI_top(config_input_output_numeric_options,config_filename, IO_setup_displa
         # the same container, so the intro header goes in the reserved top grid row (row 0), spanning
         # the full column band and centered. The logo stays .place'd in the top-left corner (place
         # coexists with grid).
-        intro.grid(row=0, column=1, columnspan=len(GUI_IO_util._GRID_COLUMN_THRESHOLDS),
+        intro.grid(row=0, column=1, columnspan=GUI_IO_util._GRID_TOTAL_COLUMNS,
                    padx=6, pady=(6, 4), sticky='w')
         display_logo()
         # although the release version appears in the top part of the GUI,

--- a/src/GUI_util.py
+++ b/src/GUI_util.py
@@ -239,7 +239,9 @@ data_tools_options_widget = tk.StringVar()
 # at import (mains bind its command before GUI_bottom runs, so it must stay the same object), which is
 # why its master is the frame from the start.
 run_close_bar = tk.Frame(window)
-run_button = GUI_theme_util.create_button(run_close_bar, text='RUN', width=10,height=2)
+# accent=True -> brand red: RUN is the single primary-action button per GUI, one of the two things
+# that earn the accent (see GUI_theme_util / the migration plan's §0). Every other button is neutral.
+run_button = GUI_theme_util.create_button(run_close_bar, text='RUN', width=10,height=2, accent=True)
 
 # license agreement GUI
 agreement_checkbox_var=tk.IntVar()
@@ -1653,9 +1655,10 @@ def GUI_bottom(config_filename, config_input_output_numeric_options, y_multiplie
             # muted=True -> grey: no videos for this GUI (restores the legacy red=available cue)
             videos_menu_lb = GUI_theme_util.create_option_menu(window, variable=videos_dropdown_field, values=[videos_options], muted=True)
         else:
-            videos_menu_lb = GUI_theme_util.create_option_menu(window, variable=videos_dropdown_field, values=[videos_options])
+            # accent=True -> red: a video IS available for this GUI
+            videos_menu_lb = GUI_theme_util.create_option_menu(window, variable=videos_dropdown_field, values=[videos_options], accent=True)
     else:
-        videos_menu_lb = GUI_theme_util.create_option_menu(window, variable=videos_dropdown_field, values=videos_options)
+        videos_menu_lb = GUI_theme_util.create_option_menu(window, variable=videos_dropdown_field, values=videos_options, accent=True)
     # place widget with hover-over info
     y_multiplier_integer = GUI_IO_util.placeWidget(window, GUI_IO_util.watch_videos_x_coordinate,
                                                    y_multiplier_integer,
@@ -1677,9 +1680,10 @@ def GUI_bottom(config_filename, config_input_output_numeric_options, y_multiplie
             # muted=True -> grey: no TIPS for this GUI (restores the legacy red=available cue)
             tips_menu_lb = GUI_theme_util.create_option_menu(window, variable=tips_dropdown_field, values=[TIPS_options], muted=True)
         else:
-            tips_menu_lb = GUI_theme_util.create_option_menu(window, variable=tips_dropdown_field, values=[TIPS_options])
+            # accent=True -> red: a TIPS file IS available for this GUI
+            tips_menu_lb = GUI_theme_util.create_option_menu(window, variable=tips_dropdown_field, values=[TIPS_options], accent=True)
     else:
-        tips_menu_lb = GUI_theme_util.create_option_menu(window, variable=tips_dropdown_field, values=TIPS_options)
+        tips_menu_lb = GUI_theme_util.create_option_menu(window, variable=tips_dropdown_field, values=TIPS_options, accent=True)
     # place widget with hover-over info
     y_multiplier_integer = GUI_IO_util.placeWidget(window, GUI_IO_util.open_TIPS_x_coordinate,
                                                    y_multiplier_integer,
@@ -1718,9 +1722,10 @@ def GUI_bottom(config_filename, config_input_output_numeric_options, y_multiplie
             # muted=True -> grey: no reminders for this GUI (restores the legacy red=available cue)
             reminders_menu_lb = GUI_theme_util.create_option_menu(window, variable=reminders_dropdown_field, values=reminder_options, muted=True)
         else:
-            reminders_menu_lb = GUI_theme_util.create_option_menu(window, variable=reminders_dropdown_field, values=reminder_options)
+            # accent=True -> red: a reminder IS available for this GUI
+            reminders_menu_lb = GUI_theme_util.create_option_menu(window, variable=reminders_dropdown_field, values=reminder_options, accent=True)
     else:
-        reminders_menu_lb = GUI_theme_util.create_option_menu(window, variable=reminders_dropdown_field, values=reminder_options)
+        reminders_menu_lb = GUI_theme_util.create_option_menu(window, variable=reminders_dropdown_field, values=reminder_options, accent=True)
     # place widget with hover-over info
     y_multiplier_integer = GUI_IO_util.placeWidget(window, GUI_IO_util.open_reminders_x_coordinate,
                                                    y_multiplier_integer,

--- a/src/GUI_util.py
+++ b/src/GUI_util.py
@@ -317,16 +317,14 @@ def display_logo():
         # https://stackoverflow.com/questions/76616042/attributeerror-module-pil-image-has-no-attribute-antialias
         image_list = [GUI_IO_util.image_libPath + os.sep + "logo.png"]
         for x in image_list:
-            img = tk_image_from_pil(Image.open(x).resize((85,50), Image.LANCZOS)) #Image.ANTIALIAS))
-            logo = tk.Label(window, width=85, height=50, anchor='nw', image=img)
+            img = tk_image_from_pil(Image.open(x).resize((58,34), Image.LANCZOS)) #Image.ANTIALIAS))
+            logo = tk.Label(window, width=58, height=34, anchor='nw', image=img)
             logo.image = img
-            # the logo has some white spaces to its left; better cutting this so that it can be aligned with HELP? buttons
-            # -12 works for Windows; must be checked for Mac
-            if platform == "win32":
-                offset=12
-            else:
-                offset=12
-            logo.place(x=GUI_IO_util.help_button_x_coordinate-offset, y=10)
+            # Left-align the logo with the ? HELP buttons. Under the grid layout those buttons sit at
+            # column 0's left padding (~6px), NOT at the legacy help_button_x_coordinate pixel (~70) --
+            # so the old `help_button_x_coordinate - 12` offset left the logo floating to their right.
+            # Place it at the same left edge instead (the image carries a little of its own whitespace).
+            logo.place(x=4, y=10)
     except Exception:
         pass  # Logo is cosmetic; skip silently if PIL/ImageTk is unavailable or incompatible
 
@@ -445,13 +443,17 @@ def display_release():
     # get_GitHub_release_version() has a double \n\n which then overwrites the first line of the GUIs: ?HELP and Setup
     GitHub_newest_release = get_GitHub_release_version().replace('\n','')
 
-    release_display = 'Release ' + str(release_version_var.get().replace('\n','')) + "/" + str(GitHub_newest_release)
-    release_lb = tk.Label(window, text=release_display, foreground="red") #height=1,
+    # Stacked on two lines ("Release" over the two version numbers) so the label's width is just the
+    # numbers (~55px) instead of the full one-line string (~150px). That width is the binding
+    # constraint on column 0's minsize below -- a wide release label was forcing a wide left column
+    # (and shoving every other column right, feeding the horizontal sprawl on the right).
+    release_display = 'Release\n' + str(release_version_var.get().replace('\n','')) + "/" + str(GitHub_newest_release)
+    release_lb = tk.Label(window, text=release_display, foreground="red", font=('TkDefaultFont', 9), justify='left') #height=1,
     # CTk migration slice 2b: the logo is .place'd in the top-left corner (y=10, ~50px tall); the
     # release label belongs directly under it. Gridding it (via placeWidget) dropped it into the tall
     # header row 0 where it rendered ON TOP OF the logo. .place it under the logo instead -- .place
     # coexists with the grid, same as the logo -- so it sits under the logo regardless of grid metrics.
-    release_lb.place(x=GUI_IO_util.help_button_x_coordinate - 12, y=64)
+    release_lb.place(x=10, y=48)
     import GUI_theme_util
     GUI_theme_util.ToolTip(release_lb,
                            "The two sets of numbers, separated by /, refer to the NLP Suite release on your machine (left) and the release available on GitHub (right)\nWithout internet the newest release available on GitHub cannnot be retrieved and is displayed as 0.0.0.")
@@ -882,6 +884,12 @@ def IO_config_setup_brief(window, y_multiplier_integer, config_filename, scriptN
 
     if config_input_output_numeric_options!=[0,0,0,0]:
         date_hover_over_label, IO_setup_display_string, config_input_output_alphabetic_options, missing_IO = set_IO_brief_values(config_filename, y_multiplier_integer)
+    # TODO(ctk-migration): DUPLICATE INPUT display box. set_IO_brief_values() (called just above)
+    # already creates AND places its own tk.Text(width=60) box, then this creates a SECOND identical
+    # one -- two side-by-side INPUT FILE/DIR boxes render on every GUI, ~450px each, driving the
+    # right-side overflow. Fix: make set_IO_brief_values() compute-and-return only (no widget), keep
+    # this single box, and have the refresh path display_IO_setup() update this box instead of
+    # letting set_IO_brief_values() recreate one. Verify file/dir selection still refreshes the box.
     IO_setup_brief_display_area = tk.Text(width=60, height=2)
     # place widget with hover-over info
     y_multiplier_integer = GUI_IO_util.placeWidget(window,
@@ -1265,11 +1273,12 @@ def GUI_top(config_input_output_numeric_options,config_filename, IO_setup_displa
         # coexists with grid).
         intro.grid(row=0, column=1, columnspan=GUI_IO_util._GRID_TOTAL_COLUMNS,
                    padx=6, pady=(6, 4), sticky='w')
-        # Reserve column 0's width for the .place'd logo + release label (they sit at x~58 and run to
-        # ~x190). Without this, column 0 sizes only to the ? HELP buttons (~140px) and the intro text
-        # in column 1 starts under the logo/release -- the overlap the user saw. minsize pushes column
-        # 1 (and every content label) to start clear of the logo zone.
-        window.grid_columnconfigure(0, minsize=210)
+        # Reserve column 0's width for the .place'd logo + release label (both sit at x~58; the 58px
+        # logo runs to ~x116, the now two-line release label to ~x113). Without this, column 0 sizes
+        # only to the ? HELP buttons (~100px) and the intro text in column 1 starts under the
+        # logo/release -- the overlap the user saw. minsize pushes column 1 (and every content label)
+        # just clear of the logo zone, keeping the left column as tight as the logo allows.
+        window.grid_columnconfigure(0, minsize=122)
         display_logo()
         # although the release version appears in the top part of the GUI,
         #   it is run at the end otherwise a message will be displayed with an incomplete GUI

--- a/src/GUI_util.py
+++ b/src/GUI_util.py
@@ -215,6 +215,10 @@ config_filename_selected_config.set('')
 
 release_version_var=tk.StringVar()
 GitHub_release_version_var=tk.StringVar()
+# Bottom edge (window y) of the .place'd logo; set by display_logo() from the logo's real rendered
+# height and read by display_release() to sit the release label just below it. Fallback used when a
+# GUI shows the release without a logo (e.g. the welcome screen).
+_logo_bottom_y = 62
 
 open_csv_output_checkbox = tk.IntVar()
 charts_package_options_widget = tk.StringVar()
@@ -329,15 +333,33 @@ def display_logo():
             bbox = ImageChops.difference(src.convert("RGB"), bg).getbbox()
             if bbox:
                 src = src.crop(bbox)
-            # Trimmed aspect ~1.82; 84x46 matches the ? HELP button width (~80px) with the buttons' left edge.
-            img = tk_image_from_pil(src.resize((84, 46), Image.LANCZOS)) #Image.ANTIALIAS))
-            logo = tk.Label(window, width=84, height=46, anchor='nw', image=img)
+            # Cropping to the ink left the letters flush against all four edges, which read as the logo
+            # being "cut off" (the P and the tail of "Suite" ran into the frame). Add a small TRANSPARENT
+            # margin (~9% of the ink each side) so the mark has breathing room; transparent (RGBA) lets
+            # the window background show through instead of a white box. Then size it into the ~100x55
+            # label -- a hair larger than the old 84x46 so the ink itself still ~matches the ? HELP
+            # button width after the margin is added. Aspect (~1.82) is preserved, so no distortion.
+            src = src.convert("RGBA")
+            mx, my = round(src.width * 0.09), round(src.height * 0.09)
+            padded = Image.new("RGBA", (src.width + 2 * mx, src.height + 2 * my), (0, 0, 0, 0))
+            padded.paste(src, (mx, my))
+            img = tk_image_from_pil(padded.resize((100, 55), Image.LANCZOS)) #Image.ANTIALIAS))
+            logo = tk.Label(window, width=100, height=55, anchor='nw', image=img)
             logo.image = img
             # Left-align the logo with the ? HELP buttons. Under the grid layout those buttons sit at
             # column 0's left padding (~6px), NOT at the legacy help_button_x_coordinate pixel (~70) --
             # so the old `help_button_x_coordinate - 12` offset left the logo floating to their right.
             # Place it at the same left edge instead (the mark is now cropped flush, no built-in margin).
             logo.place(x=4, y=10)
+            # Publish the logo's ACTUAL rendered bottom so display_release() can sit the release label
+            # directly beneath it regardless of how tall the logo renders on a given machine/DPI.
+            # winfo_reqheight() is the label's requested height (image + borders) and is valid before
+            # the window is mapped, so this is reliable even during first build. A hard-coded y for the
+            # release label was fragile: it read as overlapping the logo wherever the logo rendered
+            # taller than assumed.
+            global _logo_bottom_y
+            logo.update_idletasks()
+            _logo_bottom_y = 10 + max(logo.winfo_reqheight(), logo.winfo_height())
     except Exception:
         pass  # Logo is cosmetic; skip silently if PIL/ImageTk is unavailable or incompatible
 
@@ -461,16 +483,16 @@ def display_release():
     # constraint on column 0's minsize below -- a wide release label was forcing a wide left column
     # (and shoving every other column right, feeding the horizontal sprawl on the right).
     release_display = 'Release\n' + str(release_version_var.get().replace('\n','')) + "/" + str(GitHub_newest_release)
-    release_lb = tk.Label(window, text=release_display, foreground="red", font=('TkDefaultFont', 9), justify='left') #height=1,
-    # CTk migration slice 2b: the logo is .place'd in the top-left corner (y=10, 46px tall, so it
-    # runs to ~y=56); the release label belongs directly under it. Gridding it (via placeWidget)
-    # dropped it into the tall header row 0 where it rendered ON TOP OF the logo. .place it under the
-    # logo instead -- .place coexists with the grid, same as the logo -- so it sits under the logo
-    # regardless of grid metrics. The logo is a two-line "NLP / Suite" mark whose ink runs to the
-    # label's bottom edge (~y=56); y=62 left only ~6px, so the red "Release" line read as touching
-    # the logo. y=72 gives a clear gap below the logo (10 + 46 + 16) while staying well above the
-    # first ? HELP button row.
-    release_lb.place(x=10, y=72)
+    # font 9 rendered too small to read ("tiny release text"); 11 is legible while the two-line stack
+    # keeps the label narrow enough to stay inside column 0's minsize (so it doesn't widen the left
+    # column / push the grid right).
+    release_lb = tk.Label(window, text=release_display, foreground="red", font=('TkDefaultFont', 11), justify='left') #height=1,
+    # CTk migration slice 2b: the logo is .place'd in the top-left corner; the release label belongs
+    # directly under it. Gridding it (via placeWidget) dropped it into the tall header row 0 where it
+    # rendered ON TOP OF the logo, so .place it instead (.place coexists with the grid). Anchor it to
+    # the logo's ACTUAL rendered bottom (_logo_bottom_y, published by display_logo) plus a fixed gap
+    # -- a hard-coded y read as overlapping wherever the logo rendered taller than assumed.
+    release_lb.place(x=10, y=_logo_bottom_y + 12)
     import GUI_theme_util
     GUI_theme_util.ToolTip(release_lb,
                            "The two sets of numbers, separated by /, refer to the NLP Suite release on your machine (left) and the release available on GitHub (right)\nWithout internet the newest release available on GitHub cannnot be retrieved and is displayed as 0.0.0.")

--- a/src/GUI_util.py
+++ b/src/GUI_util.py
@@ -929,37 +929,36 @@ def IO_config_setup_brief(window, y_multiplier_integer, config_filename, scriptN
                                                    date_hover_over_label)
     update_display_area(IO_setup_display_string, IO_setup_brief_display_area)
 
-    # setup buttons to open an input file, an input directory, an output directory, and a csv config file
-    x_coordinate_hover_over = GUI_IO_util.IO_configuration_menu+GUI_IO_util.open_file_button_brief
-    # setup a button to open an input file
-    openInputFile_button = GUI_theme_util.create_open_file_button(window,
+    # Buttons to open an input file, an input directory, an output directory, and a csv config file.
+    # Grouped in ONE transparent frame (packed side by side) and gridded as a single cell. Placed
+    # individually via their old +45px x-offsets, each landed in its own far-right grid band (6,7,8,9);
+    # cross-row content widened those bands so the four sprawled apart and the last one clipped off the
+    # window's right edge. One frame keeps them a tidy cluster at the top-right on every GUI.
+    open_buttons_frame = ctk.CTkFrame(window, fg_color="transparent")
+    openInputFile_button = GUI_theme_util.create_open_file_button(open_buttons_frame,
                                      command=lambda:IO_files_util.open_file_removing_date_from_filename(window,inputFilename.get(),True))
-    # place widget with hover-over info
-    y_multiplier_integer = GUI_IO_util.placeWidget(window,GUI_IO_util.IO_configuration_menu+GUI_IO_util.open_file_button_brief, y_multiplier_integer,
-                                                   openInputFile_button, True, False, True, False, 90, x_coordinate_hover_over, "Open INPUT file")
+    openInputFile_button.pack(side=tk.LEFT, padx=2)
+    GUI_theme_util.ToolTip(openInputFile_button, "Open INPUT file")
 
-    # setup a button to open Windows Explorer on the selected INPUT directory
-    openInputDirectory_button = GUI_theme_util.create_open_file_button(window,
+    openInputDirectory_button = GUI_theme_util.create_open_file_button(open_buttons_frame,
                                      command=lambda: IO_files_util.open_directory_removing_date_from_directory(window,input_main_dir_path.get(),True))
-    # place widget with hover-over info
-    y_multiplier_integer = GUI_IO_util.placeWidget(window,GUI_IO_util.IO_configuration_menu+GUI_IO_util.open_inputDir_button_brief, y_multiplier_integer,
-                                                   openInputDirectory_button, True, False, True,False, 90, x_coordinate_hover_over, "Open INPUT files directory")
+    openInputDirectory_button.pack(side=tk.LEFT, padx=2)
+    GUI_theme_util.ToolTip(openInputDirectory_button, "Open INPUT files directory")
 
-    # setup a button to open Windows Explorer on the selected OUTPUT directory
-    openOutputDirectory_button = GUI_theme_util.create_open_file_button(window,
+    openOutputDirectory_button = GUI_theme_util.create_open_file_button(open_buttons_frame,
                                      command=lambda: IO_files_util.openExplorer(window, output_dir_path.get()))
-    # place widget with hover-over info
-    y_multiplier_integer = GUI_IO_util.placeWidget(window,GUI_IO_util.IO_configuration_menu+GUI_IO_util.open_outputDir_button_brief, y_multiplier_integer,
-                                                   openOutputDirectory_button, True, False, True,False, 90, x_coordinate_hover_over, "Open OUTPUT files directory")
+    openOutputDirectory_button.pack(side=tk.LEFT, padx=2)
+    GUI_theme_util.ToolTip(openOutputDirectory_button, "Open OUTPUT files directory")
 
-    # Open csv config file
-    openInputConfigFile_button = GUI_theme_util.create_open_file_button(window,
+    openInputConfigFile_button = GUI_theme_util.create_open_file_button(open_buttons_frame,
                                      command=lambda: openConfigFile(config_filename_selected_config.get()))
-    # place widget with hover-over info
-    y_multiplier_integer = GUI_IO_util.placeWidget(window,GUI_IO_util.IO_configuration_menu+GUI_IO_util.open_config_file_button_brief, y_multiplier_integer,
-                                                   openInputConfigFile_button, True, False, True,False, 90,
-                                                   GUI_IO_util.open_reminders_x_coordinate, "Open csv config file\nAll config files are stored in a subdirectory Config where you installed the NLP Suite; together with src, TIPS, etc.")
-    #x_coordinate_hover_over
+    openInputConfigFile_button.pack(side=tk.LEFT, padx=2)
+    GUI_theme_util.ToolTip(openInputConfigFile_button, "Open csv config file\nAll config files are stored in a subdirectory Config where you installed the NLP Suite; together with src, TIPS, etc.")
+
+    # place the whole cluster once, on the top I/O row's far-right band (no_hover_over_widget: the
+    # tooltips are attached to the individual buttons above)
+    y_multiplier_integer = GUI_IO_util.placeWidget(window,GUI_IO_util.IO_configuration_menu+GUI_IO_util.open_file_button_brief, y_multiplier_integer,
+                                                   open_buttons_frame, True, True)
 def update_display_area(IO_setup_display_string,IO_setup_brief_display_area):
 # def update_display_area(IO_setup_display_string):
 #     global IO_setup_brief_display_area

--- a/src/GUI_util.py
+++ b/src/GUI_util.py
@@ -1830,6 +1830,42 @@ def GUI_bottom(config_filename, config_input_output_numeric_options, y_multiplie
     # count toward reqwidth/reqheight), never past the screen. Grow-only, so empty margin is fine but
     # nothing is ever clipped. Also make the window resizable so the user can adjust. Scheduled
     # after_idle to run after any widgets a GUI adds past GUI_bottom.
+    def _shrink_wide_fields_to_fit(target_w):
+        # Auto-shrink pass: the old .place layout let wide widgets overlap across rows; grid forces
+        # them into separate columns whose widths SUM, so busy full-IO GUIs are far wider than the
+        # screen. Iteratively narrow the widest text-entry-style widgets (they scroll internally, so
+        # the full text is still reachable) until the content fits target_w -- and only as much as
+        # needed, so fields stay as wide as they can. Labels/checkbuttons are left alone (can't shrink
+        # without reflowing text). width is in chars for tk/ttk Entry/Text, so shrinking the number
+        # narrows them; we stop each widget once it is already narrow (reqwidth <= _FLOOR_PX).
+        _SHRINKABLE = {'Entry', 'Text', 'TEntry', 'TCombobox', 'Spinbox', 'TSpinbox'}
+        _FLOOR_PX = 150
+
+        def _all_widgets(w, acc):
+            for child in w.winfo_children():
+                acc.append(child)
+                _all_widgets(child, acc)
+            return acc
+
+        candidates = [w for w in _all_widgets(window, [])
+                      if w.winfo_class() in _SHRINKABLE]
+        for _ in range(400):
+            window.update_idletasks()
+            if window.winfo_reqwidth() <= target_w:
+                break
+            shrinkable = [w for w in candidates if w.winfo_reqwidth() > _FLOOR_PX]
+            if not shrinkable:
+                break
+            widest = max(shrinkable, key=lambda w: w.winfo_reqwidth())
+            try:
+                cur = int(widest.cget('width'))
+            except (ValueError, tk.TclError):
+                break
+            new = max(4, cur - max(1, cur // 8))
+            if new >= cur:
+                break
+            widest.configure(width=new)
+
     def _fit_window_to_content():
         try:
             window.update_idletasks()
@@ -1838,6 +1874,9 @@ def GUI_bottom(config_filename, config_input_output_numeric_options, y_multiplie
             except (ValueError, AttributeError):
                 conf_w, conf_h = 0, 0
             screen_w, screen_h = window.winfo_screenwidth(), window.winfo_screenheight()
+            # Leave a small margin from the screen edge; shrink wide fields if content exceeds it.
+            _shrink_wide_fields_to_fit(screen_w - 40)
+            window.update_idletasks()
             new_w = min(max(conf_w, window.winfo_reqwidth()), screen_w)
             # +48 reserves a strip at the bottom for the .place'd RUN/CLOSE bar (it is not in the grid,
             # so it does not count toward reqheight -- without the reserve it would overlap the chrome).

--- a/src/GUI_util.py
+++ b/src/GUI_util.py
@@ -1240,8 +1240,17 @@ def GUI_top(config_input_output_numeric_options,config_filename, IO_setup_displa
 
     # No top help lines displayed when opening the license agreement GUI
     if config_filename!='license_config.csv':
-        intro = tk.Label(window, text=GUI_IO_util.introduction_main)
-        intro.pack()
+        # wraplength keeps the multi-line intro from blowing out the grid width (without it the very
+        # long lines make column 0 span far past the window's right edge under grid). Left-anchored
+        # (sticky='w') so it's stable regardless of the window width (which is still tuned to the old
+        # absolute layout -- window sizing is a later 2b iteration item).
+        intro = tk.Label(window, text=GUI_IO_util.introduction_main, wraplength=760, justify='left')
+        # CTk migration slice 2b: the body is grid-managed now, and Tk forbids mixing grid + pack on
+        # the same container, so the intro header goes in the reserved top grid row (row 0), spanning
+        # the full column band and centered. The logo stays .place'd in the top-left corner (place
+        # coexists with grid).
+        intro.grid(row=0, column=1, columnspan=len(GUI_IO_util._GRID_COLUMN_THRESHOLDS),
+                   padx=6, pady=(6, 4), sticky='w')
         display_logo()
         # although the release version appears in the top part of the GUI,
         #   it is run at the end otherwise a message will be displayed with an incomplete GUI

--- a/src/GUI_util.py
+++ b/src/GUI_util.py
@@ -439,12 +439,14 @@ def display_release():
 
     release_display = 'Release ' + str(release_version_var.get().replace('\n','')) + "/" + str(GitHub_newest_release)
     release_lb = tk.Label(window, text=release_display, foreground="red") #height=1,
-    # place widget with hover-over info
-    y_multiplier_integer = GUI_IO_util.placeWidget(window, GUI_IO_util.help_button_x_coordinate,
-                                                   y_multiplier_integer,
-                                                   release_lb, True, False, False, False, 90,
-                                                   GUI_IO_util.help_button_x_coordinate,
-                                                   "The two sets of numbers, separated by /, refer to the NLP Suite release on your machine (left) and the release available on GitHub (right)\nWithout internet the newest release available on GitHub cannnot be retrieved and is displayed as 0.0.0.")
+    # CTk migration slice 2b: the logo is .place'd in the top-left corner (y=10, ~50px tall); the
+    # release label belongs directly under it. Gridding it (via placeWidget) dropped it into the tall
+    # header row 0 where it rendered ON TOP OF the logo. .place it under the logo instead -- .place
+    # coexists with the grid, same as the logo -- so it sits under the logo regardless of grid metrics.
+    release_lb.place(x=GUI_IO_util.help_button_x_coordinate - 12, y=64)
+    import GUI_theme_util
+    GUI_theme_util.ToolTip(release_lb,
+                           "The two sets of numbers, separated by /, refer to the NLP Suite release on your machine (left) and the release available on GitHub (right)\nWithout internet the newest release available on GitHub cannnot be retrieved and is displayed as 0.0.0.")
     # check and display a possible warning message
     if GitHub_newest_release != '0.0.0':
         check_GitHub_release(local_release_version)
@@ -1802,6 +1804,30 @@ def GUI_bottom(config_filename, config_input_output_numeric_options, y_multiplie
 
     # check_GitHub_release(local_release_version)
     window.protocol("WM_DELETE_WINDOW", _close_window)
+
+    # CTk migration slice 2b: the grid's natural width is content-driven (a wide input-file entry,
+    # the far-right RUN/CLOSE column, busy multi-control rows) and can exceed the fixed geometry
+    # set_window() guessed -- which clipped RUN/CLOSE off the right edge on several GUIs. Once every
+    # widget is laid out, GROW the window to fit its content: never below the configured size (so
+    # notebook GUIs keep the vertical space their .place'd notebook needs -- .place'd widgets don't
+    # count toward reqwidth/reqheight), never past the screen. Grow-only, so empty margin is fine but
+    # nothing is ever clipped. Also make the window resizable so the user can adjust. Scheduled
+    # after_idle to run after any widgets a GUI adds past GUI_bottom.
+    def _fit_window_to_content():
+        try:
+            window.update_idletasks()
+            try:
+                conf_w, conf_h = (int(v) for v in str(GUI_size).lower().split('x')[:2])
+            except (ValueError, AttributeError):
+                conf_w, conf_h = 0, 0
+            screen_w, screen_h = window.winfo_screenwidth(), window.winfo_screenheight()
+            new_w = min(max(conf_w, window.winfo_reqwidth()), screen_w)
+            new_h = min(max(conf_h, window.winfo_reqheight()), screen_h - 80)
+            window.geometry(f"{new_w}x{new_h}")
+            window.resizable(True, True)
+        except Exception as _e:
+            print('fit-window-to-content skipped:', _e)
+    window.after_idle(_fit_window_to_content)
 
     return package_display_area_value
 

--- a/src/NLP_menu_main.py
+++ b/src/NLP_menu_main.py
@@ -117,6 +117,12 @@ window = GUI_util.window
 # config_input_output_numeric_options = GUI_util.config_input_output_numeric_options
 # config_filename = GUI_util.config_filename
 
+# A clean, native proportional UI font to replace the legacy Courier monospace used on the SETUP
+# buttons, the red info buttons, and the notebook tabs (Courier read as dated). TkDefaultFont
+# resolves to the platform's system UI font (.AppleSystemUIFont on macOS, Segoe UI on Windows).
+import tkinter.font as _tkfont
+_ui_font_family = _tkfont.nametofont('TkDefaultFont').actual('family')
+
 GUI_util.GUI_top(config_input_output_numeric_options, config_filename, IO_setup_display_brief, scriptName)
 
 setup_IO_OK_checkbox_var = tk.IntVar()
@@ -336,14 +342,35 @@ corpus_tools_var = tk.StringVar()
 corpus_document_tools_var = tk.StringVar()
 sentence_tools_var = tk.StringVar()
 
+# Each of the three SETUP rows pairs a tiny disabled status checkbox with a very wide (95-char)
+# SETUP button. Under the coarse-band grid the checkbox and its button fall into adjacent column
+# BANDS, but those bands get stretched to ~760px each by the full-width buttons -- so the checkbox
+# was stranded at the far-left edge of its column, ~700px from its button, and the two full-width
+# button columns together (~1600px) overflowed the 1350px window, clipping the far-right open-config
+# buttons off the edge. Grouping each checkbox + button in ONE frame gridded into a single band
+# fixes both: the pair renders adjacent, and the SETUP buttons share the band with the red info
+# buttons below instead of spilling into a second full-width column.
+def _place_setup_row(y, checkbox, checkbox_tip, button, button_tip,
+                     open_button, open_button_x, open_tip):
+    import GUI_theme_util
+    row_frame = tk.Frame(window)
+    checkbox.pack(in_=row_frame, side='left')
+    button.pack(in_=row_frame, side='left', padx=(4, 0))
+    # The frame is a later-created sibling of the checkbox/button (all children of `window`), so it
+    # stacks above them and would hide them; lift the two back on top of the frame.
+    checkbox.lift(row_frame)
+    button.lift(row_frame)
+    GUI_theme_util.ToolTip(checkbox, checkbox_tip)
+    GUI_theme_util.ToolTip(button, button_tip)
+    y = GUI_IO_util.placeWidget(window, GUI_IO_util.labels_x_coordinate, y, row_frame, True, True)
+    y = GUI_IO_util.placeWidget(window, GUI_IO_util.labels_x_coordinate + open_button_x, y,
+                                open_button, False, False, True, False, 90,
+                                GUI_IO_util.open_reminders_x_coordinate, open_tip)
+    return y
+
 setup_IO_OK_checkbox = tk.Checkbutton(window, state='disabled',
                                       variable=setup_IO_OK_checkbox_var, onvalue=1, offvalue=0)
-# place widget with hover-over info
-y_multiplier_integer=GUI_IO_util.placeWidget(window,GUI_IO_util.labels_x_coordinate, y_multiplier_integer,
-                                             setup_IO_OK_checkbox,
-                                             True, False, True, False,
-                                             90, GUI_IO_util.labels_x_coordinate,
-                                             "The checkbox, always disabled, is ticked ON when the I/O options have been setup.\nIf the checkbox is OFF, click on the 'SETUP default I/O options...' button to set up.")
+setup_IO_checkbox_tip = "The checkbox, always disabled, is ticked ON when the I/O options have been setup.\nIf the checkbox is OFF, click on the 'SETUP default I/O options...' button to set up."
 
 def setup_IO():
     GUI_util.setup_IO_configuration_options(False,scriptName, silent=True, open_setup_IO_GUI=True)
@@ -361,26 +388,19 @@ def setup_IO_checkbox():
     else:
         setup_IO_OK_checkbox_var.set(0)
 
-IO_setup_button = tk.Button(window, text='SETUP default I/O options: INPUT file/directory (corpus) and OUTPUT files directory', width=95, font=("Courier", 10, "bold"), command=lambda: setup_IO())
-# place widget with hover-over info
-y_multiplier_integer = GUI_IO_util.placeWidget(window, GUI_IO_util.labels_x_coordinate+30,
-                                               y_multiplier_integer,
-                                               IO_setup_button, True, False, False, False, 90,
-                                               GUI_IO_util.labels_x_coordinate+30,
-                                               "You will probably use the same document(s) (i.e., corpus), written in the same language, for different analyses using different NLP tools, and exporting results to the same directory.\n Click on the SETUP button to setup Input/Output (I/O) options.\nYour selected options will be used as default in all GUIs; but you can change your preferences at any time; and every GUI also allows you to setup GUI-specific I/O options.")
+IO_setup_button = tk.Button(window, text='SETUP default I/O options: INPUT file/directory (corpus) and OUTPUT files directory', width=95, font=(_ui_font_family, 12, "bold"), command=lambda: setup_IO())
+setup_IO_button_tip = "You will probably use the same document(s) (i.e., corpus), written in the same language, for different analyses using different NLP tools, and exporting results to the same directory.\n Click on the SETUP button to setup Input/Output (I/O) options.\nYour selected options will be used as default in all GUIs; but you can change your preferences at any time; and every GUI also allows you to setup GUI-specific I/O options."
 
-open_default_IO_config_button = tk.Button(window, width=GUI_IO_util.open_file_directory_button_width, text='', command=lambda: IO_files_util.openFile(window, GUI_IO_util.configPath+os.sep+'NLP_default_IO_config.csv'))
-y_multiplier_integer = GUI_IO_util.placeWidget(window,GUI_IO_util.labels_x_coordinate+GUI_IO_util.open_IO_config_button, y_multiplier_integer,
-                                               open_default_IO_config_button, False, False, True, False, 90, GUI_IO_util.open_reminders_x_coordinate, "Open the NLP_default_IO_config.csv file containing the default Input/Output options")
+open_default_IO_config_button = tk.Button(window, width=3, text='\U0001F4C2', command=lambda: IO_files_util.openFile(window, GUI_IO_util.configPath+os.sep+'NLP_default_IO_config.csv'))
+y_multiplier_integer = _place_setup_row(y_multiplier_integer,
+                                        setup_IO_OK_checkbox, setup_IO_checkbox_tip,
+                                        IO_setup_button, setup_IO_button_tip,
+                                        open_default_IO_config_button, GUI_IO_util.open_IO_config_button,
+                                        "Open the NLP_default_IO_config.csv file containing the default Input/Output options")
 
 setup_parsers_annotators_OK_checkbox = tk.Checkbutton(window, state='disabled',
                                       variable=setup_parsers_annotators_OK_checkbox_var, onvalue=1, offvalue=0)
-# place widget with hover-over info
-y_multiplier_integer=GUI_IO_util.placeWidget(window,GUI_IO_util.labels_x_coordinate, y_multiplier_integer,
-                                             setup_parsers_annotators_OK_checkbox,
-                                             True, False, True, False,
-                                             90, GUI_IO_util.labels_x_coordinate,
-                                             "The checkbox, always disabled, is ticked ON when the parser/annotator and corpus language options have been setup.\nIf the checkbox is OFF, click on the 'SETUP default NLP parser...' button to set up.")
+setup_parsers_annotators_checkbox_tip = "The checkbox, always disabled, is ticked ON when the parser/annotator and corpus language options have been setup.\nIf the checkbox is OFF, click on the 'SETUP default NLP parser...' button to set up."
 
 NLP_package_language_config = GUI_IO_util.configPath+os.sep+'NLP_default_package_language_config.csv'
 def setup_parsers_annotators_checkbox(NLP_package_language_config):
@@ -396,26 +416,19 @@ def _setup_parsers_and_recheck():
     run_script_util.run_script("NLP_setup_package_language_main.py")
     setup_parsers_annotators_checkbox(NLP_package_language_config)
 
-NLP_package_language_setup_button = tk.Button(window, text='SETUP default NLP parsers & annotators package and default corpus language', width=95, font=("Courier", 10, "bold"), command=_setup_parsers_and_recheck)
-# place widget with hover-over info
-y_multiplier_integer = GUI_IO_util.placeWidget(window, GUI_IO_util.labels_x_coordinate+30,
-                                               y_multiplier_integer,
-                                               NLP_package_language_setup_button, True, False, False, False, 90,
-                                               GUI_IO_util.labels_x_coordinate+30,
-                                               "The NLP Suite relies on a handful of external software to carry out specialized tasks (e.g., Stanford CoreNLP, Gephi).\nClick on the Setup button to select your preferred parser software (e.g., Stanford CoreNLP) and the laguage of your corpus (e.g., English)\nYour selected options will be used as default in all GUIs; but you can change your preferences at any time.")
+NLP_package_language_setup_button = tk.Button(window, text='SETUP default NLP parsers & annotators package and default corpus language', width=95, font=(_ui_font_family, 12, "bold"), command=_setup_parsers_and_recheck)
+setup_parsers_annotators_button_tip = "The NLP Suite relies on a handful of external software to carry out specialized tasks (e.g., Stanford CoreNLP, Gephi).\nClick on the Setup button to select your preferred parser software (e.g., Stanford CoreNLP) and the laguage of your corpus (e.g., English)\nYour selected options will be used as default in all GUIs; but you can change your preferences at any time."
 
-open_default_NLP_package_language_config_button = tk.Button(window, width=GUI_IO_util.open_file_directory_button_width, text='', command=lambda: IO_files_util.openFile(window, NLP_package_language_config))
-y_multiplier_integer = GUI_IO_util.placeWidget(window,GUI_IO_util.labels_x_coordinate+GUI_IO_util.open_NLP_package_language_config_button, y_multiplier_integer,
-                                               open_default_NLP_package_language_config_button, False, False, True, False, 90, GUI_IO_util.open_TIPS_x_coordinate, "Open the NLP_default_package_language_config.csv file containing the default NLP parser and annotators and corpus language options")
+open_default_NLP_package_language_config_button = tk.Button(window, width=3, text='\U0001F4C2', command=lambda: IO_files_util.openFile(window, NLP_package_language_config))
+y_multiplier_integer = _place_setup_row(y_multiplier_integer,
+                                        setup_parsers_annotators_OK_checkbox, setup_parsers_annotators_checkbox_tip,
+                                        NLP_package_language_setup_button, setup_parsers_annotators_button_tip,
+                                        open_default_NLP_package_language_config_button, GUI_IO_util.open_NLP_package_language_config_button,
+                                        "Open the NLP_default_package_language_config.csv file containing the default NLP parser and annotators and corpus language options")
 
 setup_external_software_checkbox = tk.Checkbutton(window, state='disabled',
                                          variable=setup_external_software_OK_checkbox_var, onvalue=1, offvalue=0, command=lambda: setup_external_programs_checkbox())
-# place widget with hover-over info
-y_multiplier_integer=GUI_IO_util.placeWidget(window,GUI_IO_util.labels_x_coordinate, y_multiplier_integer,
-                                             setup_external_software_checkbox,
-                                             True, False, True, False,
-                                             90, GUI_IO_util.labels_x_coordinate,
-                                             "The checkbox, always disabled, is ticked ON when all external software have been installed.\nIf the checkbox is OFF, click on the 'SETUP external software' button to set up.")
+setup_external_software_checkbox_tip = "The checkbox, always disabled, is ticked ON when all external software have been installed.\nIf the checkbox is OFF, click on the 'SETUP external software' button to set up."
 
 software_dir = ''
 
@@ -452,22 +465,20 @@ def setup_external_software():
     setup_external_programs_checkbox()
 
 # software_setup_button = tk.Button(window, text='Setup external software', width=95, font=("Courier", 10, "bold"), command=lambda: setup_external_software_warning())
-software_setup_button = tk.Button(window, text='SETUP external software', width=95, font=("Courier", 10, "bold"), command=lambda: setup_external_software())
-# place widget with hover-over info
-y_multiplier_integer = GUI_IO_util.placeWidget(window, GUI_IO_util.labels_x_coordinate+30,
-                                               y_multiplier_integer,
-                                               software_setup_button, True, False, False, False, 90,
-                                               GUI_IO_util.labels_x_coordinate+30,
-                                               "The NLP Suite relies on a handful of external software to carry out specialized tasks (e.g., Stanford CoreNLP, Gephi)\nClick on the Setup button to download and install these freeware software packages\nYou only have to do this once")
+software_setup_button = tk.Button(window, text='SETUP external software', width=95, font=(_ui_font_family, 12, "bold"), command=lambda: setup_external_software())
+setup_external_software_button_tip = "The NLP Suite relies on a handful of external software to carry out specialized tasks (e.g., Stanford CoreNLP, Gephi)\nClick on the Setup button to download and install these freeware software packages\nYou only have to do this once"
 
-open_setup_button = tk.Button(window, width=GUI_IO_util.open_file_directory_button_width, text='', command=lambda: IO_files_util.openFile(window, GUI_IO_util.configPath+os.sep+'NLP_setup_external_software_config.csv'))
-y_multiplier_integer = GUI_IO_util.placeWidget(window,GUI_IO_util.labels_x_coordinate+GUI_IO_util.open_setup_external_software_button, y_multiplier_integer,
-                                               open_setup_button, False, False, True, False, 90, GUI_IO_util.open_reminders_x_coordinate, "Open the NLP_setup_external_software_config.csv file containing all external software installation paths")
+open_setup_button = tk.Button(window, width=3, text='\U0001F4C2', command=lambda: IO_files_util.openFile(window, GUI_IO_util.configPath+os.sep+'NLP_setup_external_software_config.csv'))
+y_multiplier_integer = _place_setup_row(y_multiplier_integer,
+                                        setup_external_software_checkbox, setup_external_software_checkbox_tip,
+                                        software_setup_button, setup_external_software_button_tip,
+                                        open_setup_button, GUI_IO_util.open_setup_external_software_button,
+                                        "Open the NLP_setup_external_software_config.csv file containing all external software installation paths")
 
 # CORPUS LANGUAGE & NLP options available in the Suite
 corpus_language_button = tk.Button(window,
                                    text="Which NLP tools in the Suite can I use with my corpus language?",
-                                   width=95, font=("Courier", 11, "bold"), fg='red',
+                                   width=95, font=(_ui_font_family, 13, "bold"), fg='red',
                                    command=lambda: language_tools_advisor_util.run(
                                        outputDir=GUI_util.output_dir_path.get()))
 y_multiplier_integer = GUI_IO_util.placeWidget(window, GUI_IO_util.labels_x_coordinate + 30,
@@ -480,7 +491,7 @@ y_multiplier_integer = GUI_IO_util.placeWidget(window, GUI_IO_util.labels_x_coor
 # top of the tool list. Placement/wording easy to tweak.
 corpus_profiler_button = tk.Button(window,
                                    text="CORPUS PROFILER  —  what's in your corpus? one click → an HTML report and a paper-style summary",
-                                   width=95, font=("Courier", 11, "bold"), fg='red',
+                                   width=95, font=(_ui_font_family, 13, "bold"), fg='red',
                                    command=lambda: run_script_util.run_script("corpus_profiler_main.py"))
 y_multiplier_integer = GUI_IO_util.placeWidget(window, GUI_IO_util.labels_x_coordinate + 30,
                                                y_multiplier_integer,
@@ -498,13 +509,15 @@ try:
     nb_style.theme_use('clam')
 except Exception:
     pass
-nb_style.configure('NLP.TNotebook.Tab', font=("Courier", 11, "bold"), foreground='red', padding=[16, 5])
+nb_style.configure('NLP.TNotebook.Tab', font=(_ui_font_family, 12, "bold"), foreground='red', padding=[16, 5])
 nb_style.map('NLP.TNotebook.Tab',
              background=[('selected', '#d0e0f0'), ('!selected', '#e8e8e8')],
              foreground=[('selected', 'red'), ('!selected', '#999999')])
 
 nb_width = GUI_width - GUI_IO_util.labels_x_coordinate - 20
-nb_height = 210
+# Snug height: three ~28px rows starting at y=12 end near y=124, so 150 leaves a small bottom margin
+# instead of the ~85px of dead gray the old 210 left below the dropdowns.
+nb_height = 150
 tools_notebook = ttk.Notebook(window, style='NLP.TNotebook')
 # CTk migration slice 2b: the body is grid-managed now, so the notebook must be GRIDded too -- the
 # old .place(y = 90 + 40*y_multiplier) put it at a pixel-y the grid no longer uses, so it floated
@@ -513,7 +526,7 @@ tools_notebook = ttk.Notebook(window, style='NLP.TNotebook')
 # turn OFF geometry propagation, otherwise the gridded notebook would collapse to zero height.
 tools_notebook.grid(row=GUI_IO_util._GRID_HEADER_ROWS + int(round(y_multiplier_integer)),
                     column=0, columnspan=GUI_IO_util._GRID_TOTAL_COLUMNS,
-                    padx=(GUI_IO_util.labels_x_coordinate, 10), pady=6, sticky='we')
+                    padx=(GUI_IO_util.labels_x_coordinate, 10), pady=6, sticky='w')
 
 tab_linguistic = ttk.Frame(tools_notebook, width=nb_width, height=nb_height)
 tab_utility = ttk.Frame(tools_notebook, width=nb_width, height=nb_height)
@@ -533,7 +546,9 @@ _ROW_STEP = 42
 
 def _tab_row(parent, row_y, label_text, combobox, help_message):
     tk.Label(parent, text=label_text).place(x=10, y=row_y + 3)
-    combobox.place(x=250, y=row_y)
+    # Explicit pixel width: the themed combobox's char-based width renders only ~150px, leaving the
+    # dropdown marooned in a wide empty gray band. Stretch it to fill the row up to the ? HELP button.
+    combobox.place(x=250, y=row_y, width=_tab_help_x - 250 - 20)
     tk.Button(parent, text='? HELP',
               command=lambda m=help_message: mb.showinfo("NLP Suite Help", m)).place(x=_tab_help_x, y=row_y)
 

--- a/src/NLP_menu_main.py
+++ b/src/NLP_menu_main.py
@@ -503,14 +503,22 @@ nb_style.map('NLP.TNotebook.Tab',
              background=[('selected', '#d0e0f0'), ('!selected', '#e8e8e8')],
              foreground=[('selected', 'red'), ('!selected', '#999999')])
 
-notebook_y = GUI_IO_util.basic_y_coordinate + GUI_IO_util.y_step * y_multiplier_integer
 nb_width = GUI_width - GUI_IO_util.labels_x_coordinate - 20
 nb_height = 210
 tools_notebook = ttk.Notebook(window, style='NLP.TNotebook')
-tools_notebook.place(x=GUI_IO_util.labels_x_coordinate, y=notebook_y, width=nb_width, height=nb_height)
+# CTk migration slice 2b: the body is grid-managed now, so the notebook must be GRIDded too -- the
+# old .place(y = 90 + 40*y_multiplier) put it at a pixel-y the grid no longer uses, so it floated
+# over the chrome. Grid it into the current row, spanning the full column band. The tab frames hold
+# .place'd children (which give a frame no natural size), so pin each frame to an explicit size and
+# turn OFF geometry propagation, otherwise the gridded notebook would collapse to zero height.
+tools_notebook.grid(row=GUI_IO_util._GRID_HEADER_ROWS + int(round(y_multiplier_integer)),
+                    column=0, columnspan=GUI_IO_util._GRID_TOTAL_COLUMNS,
+                    padx=(GUI_IO_util.labels_x_coordinate, 10), pady=6, sticky='we')
 
-tab_linguistic = ttk.Frame(tools_notebook)
-tab_utility = ttk.Frame(tools_notebook)
+tab_linguistic = ttk.Frame(tools_notebook, width=nb_width, height=nb_height)
+tab_utility = ttk.Frame(tools_notebook, width=nb_width, height=nb_height)
+tab_linguistic.pack_propagate(False)
+tab_utility.pack_propagate(False)
 # Linguistic tools are the suite's raison d'être -> make them the FIRST tab, so they are the
 # default selected tab on every launch; General Utility tools follow as the supporting cast.
 tools_notebook.add(tab_linguistic, text='   Linguistic Analysis Tools   ')

--- a/src/ctk_bundle_util.py
+++ b/src/ctk_bundle_util.py
@@ -1,0 +1,82 @@
+"""CustomTkinter bundle compatibility shim (CTk migration — docs/CustomTkinter-Migration-Plan.md §5.1).
+
+CTk's ``CTkImage`` builds its Tk image with ``PIL.ImageTk.PhotoImage``. Under the portable
+python-build-standalone interpreter that ships in the NLP Suite installer, Tcl/Tk is *statically
+embedded*, so the ``_imagingtk`` C bridge cannot attach and every ``PIL.ImageTk`` call crashes
+(``TypeError: bad argument type for built-in operation`` / ``invalid command name "PyImagingPhoto"``).
+This is the same root cause that ``GUI_util.tk_image_from_pil`` was written to solve for the plain
+``tk.Label`` logo path, and the reason the matplotlib ``TkAgg`` backend had to fall back to ``Agg``.
+
+``patch_ctk_image_for_bundle()`` monkeypatches the two ``CTkImage`` methods that touch ImageTk so
+they hand Tk base64-encoded PNG bytes through the plain ``tk.PhotoImage(data=…)`` API instead —
+Tk 8.6 decodes PNG natively, and PIL is used only to resize/encode, never touching ``_imagingtk``.
+With the patch applied, ``CTkImage`` works under the bundle, so Phase 1+ can use CTk's native image
+idiom instead of banning ``CTkImage`` outright.
+
+Kept deliberately free of import-time side effects (no Tk root, no heavy imports) so the Phase 0
+bundle smoke test can import it under the standalone interpreter. Call ``patch_ctk_image_for_bundle()``
+once at startup, before any ``CTkImage`` is created.
+"""
+import base64
+import io
+import tkinter as tk
+
+_patched = False
+
+
+def _tk_photoimage_from_pil(pil_image):
+    """Build a plain ``tk.PhotoImage`` from a PIL image via base64 PNG, bypassing ``PIL.ImageTk``.
+
+    Mirror of ``GUI_util.tk_image_from_pil`` (kept local so this module imports without pulling in
+    GUI_util's Tk-root import side effects; see module docstring). Keep a reference to the returned
+    image — Tk does not.
+    """
+    if pil_image.mode not in ("RGB", "RGBA", "L", "LA", "P"):
+        pil_image = pil_image.convert("RGBA")
+    buffer = io.BytesIO()
+    pil_image.save(buffer, format="PNG")
+    return tk.PhotoImage(data=base64.b64encode(buffer.getvalue()))
+
+
+def patch_ctk_image_for_bundle():
+    """Route ``CTkImage``'s Tk-image construction through the base64-PNG path (see module docstring).
+
+    Idempotent. Returns True if the patch is in place, False if CustomTkinter is not importable.
+    Raises RuntimeError if CTkImage is present but its internals differ from what we patch (so a
+    CustomTkinter upgrade that moves these methods fails loudly at startup rather than crashing
+    later inside the bundle).
+    """
+    global _patched
+    if _patched:
+        return True
+
+    try:
+        from customtkinter.windows.widgets.image.ctk_image import CTkImage
+    except ImportError:
+        return False
+
+    if not (hasattr(CTkImage, "_get_scaled_light_photo_image")
+            and hasattr(CTkImage, "_get_scaled_dark_photo_image")):
+        raise RuntimeError(
+            "ctk_bundle_util: CTkImage internals changed; the bundle ImageTk workaround needs "
+            "updating (see docs/CustomTkinter-Migration-Plan.md §5.1)."
+        )
+
+    def _get_scaled_light_photo_image(self, scaled_size):
+        if scaled_size not in self._scaled_light_photo_images:
+            self._scaled_light_photo_images[scaled_size] = _tk_photoimage_from_pil(
+                self._light_image.resize(scaled_size)
+            )
+        return self._scaled_light_photo_images[scaled_size]
+
+    def _get_scaled_dark_photo_image(self, scaled_size):
+        if scaled_size not in self._scaled_dark_photo_images:
+            self._scaled_dark_photo_images[scaled_size] = _tk_photoimage_from_pil(
+                self._dark_image.resize(scaled_size)
+            )
+        return self._scaled_dark_photo_images[scaled_size]
+
+    CTkImage._get_scaled_light_photo_image = _get_scaled_light_photo_image
+    CTkImage._get_scaled_dark_photo_image = _get_scaled_dark_photo_image
+    _patched = True
+    return True

--- a/src/data_visualization_main.py
+++ b/src/data_visualization_main.py
@@ -619,20 +619,27 @@ nb_style.map('Viz.TNotebook.Tab',
              background=[('selected', '#d0e0f0'), ('!selected', '#e8e8e8')],
              foreground=[('selected', 'red'), ('!selected', '#999999')])
 
-# Save the current y position for the notebook
-notebook_y = 90 + 40 * y_multiplier_integer
-
+# CTk migration slice 2b: GRID the notebook into the current row instead of .place'ing it at the old
+# pixel-y (90 + 40*y_multiplier) -- under the grid layout that y no longer matches where the chrome
+# sits, so the notebook floated over the controls. The tab frames hold .place'd children (no natural
+# size), so pin each to an explicit size with propagation OFF or the gridded notebook collapses.
+_nb_width = GUI_IO_util.get_GUI_width(3) - GUI_IO_util.labels_x_coordinate - 20
+_nb_height = 310
 notebook = ttk.Notebook(window, style='Viz.TNotebook')
-notebook.place(x=GUI_IO_util.labels_x_coordinate, y=notebook_y,
-               width=GUI_IO_util.get_GUI_width(3) - GUI_IO_util.labels_x_coordinate - 20, height=310)
+notebook.grid(row=GUI_IO_util._GRID_HEADER_ROWS + int(round(y_multiplier_integer)),
+              column=0, columnspan=GUI_IO_util._GRID_TOTAL_COLUMNS,
+              padx=(GUI_IO_util.labels_x_coordinate, 10), pady=6, sticky='we')
 
-tab_relational = ttk.Frame(notebook)
-tab_categorical = ttk.Frame(notebook)
-tab_temporal = ttk.Frame(notebook)
-tab_numeric = ttk.Frame(notebook)
-tab_geographic = ttk.Frame(notebook)
-tab_wordclouds = ttk.Frame(notebook)
-tab_tree = ttk.Frame(notebook)
+tab_relational = ttk.Frame(notebook, width=_nb_width, height=_nb_height)
+tab_categorical = ttk.Frame(notebook, width=_nb_width, height=_nb_height)
+tab_temporal = ttk.Frame(notebook, width=_nb_width, height=_nb_height)
+tab_numeric = ttk.Frame(notebook, width=_nb_width, height=_nb_height)
+tab_geographic = ttk.Frame(notebook, width=_nb_width, height=_nb_height)
+tab_wordclouds = ttk.Frame(notebook, width=_nb_width, height=_nb_height)
+tab_tree = ttk.Frame(notebook, width=_nb_width, height=_nb_height)
+for _tab in (tab_relational, tab_categorical, tab_temporal, tab_numeric,
+             tab_geographic, tab_wordclouds, tab_tree):
+    _tab.pack_propagate(False)
 
 notebook.add(tab_relational, text=' Relational ')
 notebook.add(tab_categorical, text=' Categorical ')

--- a/src/nlp_suite_theme.json
+++ b/src/nlp_suite_theme.json
@@ -1,0 +1,157 @@
+{
+  "CTk": {
+    "fg_color": ["gray92", "gray14"]
+  },
+  "CTkToplevel": {
+    "fg_color": ["gray92", "gray14"]
+  },
+  "CTkFrame": {
+    "corner_radius": 6,
+    "border_width": 0,
+    "fg_color": ["gray86", "gray17"],
+    "top_fg_color": ["gray81", "gray20"],
+    "border_color": ["gray65", "gray28"]
+  },
+  "CTkButton": {
+    "corner_radius": 6,
+    "border_width": 0,
+    "fg_color": ["#7E868D", "#4A4D50"],
+    "hover_color": ["#6B7278", "#5A5D60"],
+    "border_color": ["#3E454A", "#949A9F"],
+    "text_color": ["#FFFFFF", "#F2F2F2"],
+    "text_color_disabled": ["gray78", "gray60"]
+  },
+  "CTkLabel": {
+    "corner_radius": 0,
+    "border_width": 0,
+    "fg_color": "transparent",
+    "border_color": ["#979DA2", "#565B5E"],
+    "text_color": ["gray10", "#DCE4EE"]
+  },
+  "CTkEntry": {
+    "corner_radius": 6,
+    "border_width": 2,
+    "fg_color": ["#F9F9FA", "#343638"],
+    "border_color": ["#979DA2", "#565B5E"],
+    "text_color": ["gray10", "#DCE4EE"],
+    "placeholder_text_color": ["gray52", "gray62"]
+  },
+  "CTkCheckBox": {
+    "corner_radius": 6,
+    "border_width": 3,
+    "fg_color": ["#7E868D", "#4A4D50"],
+    "border_color": ["#3E454A", "#949A9F"],
+    "hover_color": ["#6B7278", "#5A5D60"],
+    "checkmark_color": ["#FFFFFF", "gray90"],
+    "text_color": ["gray10", "#DCE4EE"],
+    "text_color_disabled": ["gray60", "gray45"]
+  },
+  "CTkSwitch": {
+    "corner_radius": 1000,
+    "border_width": 3,
+    "button_length": 0,
+    "fg_color": ["#939BA2", "#4A4D50"],
+    "progress_color": ["#7E868D", "#5A5D60"],
+    "button_color": ["gray36", "#D5D9DE"],
+    "button_hover_color": ["gray20", "gray100"],
+    "text_color": ["gray10", "#DCE4EE"],
+    "text_color_disabled": ["gray60", "gray45"]
+  },
+  "CTkRadioButton": {
+    "corner_radius": 1000,
+    "border_width_checked": 6,
+    "border_width_unchecked": 3,
+    "fg_color": ["#7E868D", "#4A4D50"],
+    "border_color": ["#3E454A", "#949A9F"],
+    "hover_color": ["#6B7278", "#5A5D60"],
+    "text_color": ["gray10", "#DCE4EE"],
+    "text_color_disabled": ["gray60", "gray45"]
+  },
+  "CTkProgressBar": {
+    "corner_radius": 1000,
+    "border_width": 0,
+    "fg_color": ["#939BA2", "#4A4D50"],
+    "progress_color": ["#7E868D", "#AAB0B5"],
+    "border_color": ["gray", "gray"]
+  },
+  "CTkSlider": {
+    "corner_radius": 1000,
+    "button_corner_radius": 1000,
+    "border_width": 6,
+    "button_length": 0,
+    "fg_color": ["#939BA2", "#4A4D50"],
+    "progress_color": ["gray40", "#AAB0B5"],
+    "button_color": ["#7E868D", "#4A4D50"],
+    "button_hover_color": ["#6B7278", "#5A5D60"]
+  },
+  "CTkOptionMenu": {
+    "corner_radius": 6,
+    "fg_color": ["#7E868D", "#4A4D50"],
+    "button_color": ["#6B7278", "#3E4145"],
+    "button_hover_color": ["#5A6167", "#4A4D50"],
+    "text_color": ["#FFFFFF", "#F2F2F2"],
+    "text_color_disabled": ["gray78", "gray60"]
+  },
+  "CTkComboBox": {
+    "corner_radius": 6,
+    "border_width": 2,
+    "fg_color": ["#F9F9FA", "#343638"],
+    "border_color": ["#979DA2", "#565B5E"],
+    "button_color": ["#7E868D", "#4A4D50"],
+    "button_hover_color": ["#6B7278", "#5A5D60"],
+    "text_color": ["gray10", "#DCE4EE"],
+    "text_color_disabled": ["gray50", "gray45"]
+  },
+  "CTkScrollbar": {
+    "corner_radius": 1000,
+    "border_spacing": 4,
+    "fg_color": "transparent",
+    "button_color": ["gray55", "gray41"],
+    "button_hover_color": ["gray40", "gray53"]
+  },
+  "CTkSegmentedButton": {
+    "corner_radius": 6,
+    "border_width": 2,
+    "fg_color": ["#979DA2", "gray29"],
+    "selected_color": ["#7E868D", "#4A4D50"],
+    "selected_hover_color": ["#6B7278", "#5A5D60"],
+    "unselected_color": ["#979DA2", "gray29"],
+    "unselected_hover_color": ["gray70", "gray41"],
+    "text_color": ["#FFFFFF", "#F2F2F2"],
+    "text_color_disabled": ["gray78", "gray60"]
+  },
+  "CTkTextbox": {
+    "corner_radius": 6,
+    "border_width": 0,
+    "fg_color": ["#F9F9FA", "#1D1E1E"],
+    "border_color": ["#979DA2", "#565B5E"],
+    "text_color": ["gray10", "#DCE4EE"],
+    "scrollbar_button_color": ["gray55", "gray41"],
+    "scrollbar_button_hover_color": ["gray40", "gray53"]
+  },
+  "CTkScrollableFrame": {
+    "label_fg_color": ["gray78", "gray23"]
+  },
+  "DropdownMenu": {
+    "fg_color": ["gray90", "gray20"],
+    "hover_color": ["gray75", "gray25"],
+    "text_color": ["gray10", "gray90"]
+  },
+  "CTkFont": {
+    "macOS": {
+      "family": "SF Display",
+      "size": 13,
+      "weight": "normal"
+    },
+    "Windows": {
+      "family": "Roboto",
+      "size": 13,
+      "weight": "normal"
+    },
+    "Linux": {
+      "family": "Roboto",
+      "size": 13,
+      "weight": "normal"
+    }
+  }
+}

--- a/src/statistics_csv_main.py
+++ b/src/statistics_csv_main.py
@@ -12,6 +12,7 @@ import tkinter.messagebox as mb
 import tkinter.filedialog
 
 import GUI_IO_util
+import GUI_theme_util
 import IO_csv_util
 import IO_user_interface_util
 import IO_files_util
@@ -369,7 +370,7 @@ input_csv_file_button = tk.Button(window, width=GUI_IO_util.select_file_director
 y_multiplier_integer = GUI_IO_util.placeWidget(window, GUI_IO_util.labels_x_coordinate, y_multiplier_integer,
                                                input_csv_file_button, True)
 
-open_input_csv_file_button = tk.Button(window, width=GUI_IO_util.open_file_directory_button_width, text='',
+open_input_csv_file_button = GUI_theme_util.create_open_file_button(window,
                                        command=lambda: IO_files_util.openFile(window, input_csv_file_var.get()))
 y_multiplier_integer = GUI_IO_util.placeWidget(window, GUI_IO_util.IO_configuration_menu, y_multiplier_integer,
                                                open_input_csv_file_button,

--- a/src/wordclouds_main.py
+++ b/src/wordclouds_main.py
@@ -9,7 +9,6 @@ if IO_libraries_util.install_all_Python_packages(GUI_util.window,"Wordclouds",['
 
 import os
 import tkinter as tk
-import tkinter.ttk as ttk
 import tkinter.messagebox as mb
 from subprocess import call
 
@@ -17,6 +16,7 @@ from subprocess import call
 import IO_internet_util
 import IO_files_util
 import GUI_IO_util
+import GUI_theme_util
 import IO_csv_util
 import reminders_util
 import config_util
@@ -213,7 +213,7 @@ def clear(e):
     wordclouds_var.set('Python WordCloud')
     font_var.set('Default')
     differentColumns_differentColor_var.set(0)
-    differentColumns_differentColor_checkbox.config(state='normal')
+    differentColumns_differentColor_checkbox.configure(state='normal')
     wordcloud_title_var.set('')
     selectedImage_var.set('')
     use_contour_only_var.set(1)
@@ -245,11 +245,12 @@ extra_GUIs_var = tk.IntVar()
 extra_GUIs_menu_var = tk.StringVar()
 
 extra_GUIs_var.set(0)
-extra_GUIs_checkbox = tk.Checkbutton(window, text='GUIs available for more analyses ', variable=extra_GUIs_var, onvalue=1, offvalue=0, command=lambda: activate_GUI_options())
+extra_GUIs_checkbox = GUI_theme_util.create_checkbox(window, text='GUIs available for more analyses ', variable=extra_GUIs_var, onvalue=1, offvalue=0, command=lambda: activate_GUI_options())
 y_multiplier_integer=GUI_IO_util.placeWidget(window,GUI_IO_util.labels_x_coordinate,y_multiplier_integer,extra_GUIs_checkbox,True)
 
 extra_GUIs_menu_var.set('')
-extra_GUIs_menu = tk.OptionMenu(window,extra_GUIs_menu_var,'Statistics csv file','Data visualization','Parsers & annotators')
+extra_GUIs_menu = GUI_theme_util.create_option_menu(window, variable=extra_GUIs_menu_var,
+                                                    values=['Statistics csv file', 'Data visualization', 'Parsers & annotators'])
 extra_GUIs_menu.configure(state='disabled')
 # place widget with hover-over info
 y_multiplier_integer = GUI_IO_util.placeWidget(window,GUI_IO_util.IO_configuration_menu, y_multiplier_integer,
@@ -279,32 +280,33 @@ def activate_GUI_options():
 wordclouds_var.set('Python WordCloud')
 selectedImage_var.set('')
 use_contour_only_var.set(1)
-wordclouds = tk.OptionMenu(window,wordclouds_var,'Python WordCloud','TagCrowd','Tagul','Tagxedo','Wordclouds','Wordle')
+wordclouds = GUI_theme_util.create_option_menu(window, variable=wordclouds_var,
+                                               values=['Python WordCloud', 'TagCrowd', 'Tagul', 'Tagxedo', 'Wordclouds', 'Wordle'])
 y_multiplier_integer=GUI_IO_util.placeWidget(window,GUI_IO_util.entry_box_x_coordinate+120, y_multiplier_integer,wordclouds,True)
-wordclouds_lb = tk.Label(window, text='Select the word cloud service you wish to use (txt file(s)/CoNLL table)')
+wordclouds_lb = GUI_theme_util.create_label(window, text='Select the word cloud service you wish to use (txt file(s)/CoNLL table)')
 y_multiplier_integer=GUI_IO_util.placeWidget(window,GUI_IO_util.labels_x_coordinate,y_multiplier_integer,wordclouds_lb)
 
 y_multiplier_integer_SV=y_multiplier_integer
 
 differentPOS_differentColor_var.set(0)
-differentPOS_differentColor_checkbox = tk.Checkbutton(window, variable=differentPOS_differentColor_var,
+differentPOS_differentColor_checkbox = GUI_theme_util.create_checkbox(window, variable=differentPOS_differentColor_var,
                                                        onvalue=1, offvalue=0)
 
-wordcloud_title_lb = tk.Label(window, text='Wordcloud title')
+wordcloud_title_lb = GUI_theme_util.create_label(window, text='Wordcloud title')
 y_multiplier_integer=GUI_IO_util.placeWidget(window,GUI_IO_util.labels_x_indented_coordinate, y_multiplier_integer,wordcloud_title_lb,True)
 
-wordcloud_title = tk.Entry(window, width=GUI_IO_util.widget_width_medium,textvariable=wordcloud_title_var)
-# selectedImage.config(state='disabled')
+wordcloud_title = GUI_theme_util.create_entry(window, width=GUI_IO_util.widget_width_medium,textvariable=wordcloud_title_var)
+# selectedImage.configure(state='disabled')
 y_multiplier_integer = GUI_IO_util.placeWidget(window,GUI_IO_util.wordcloud_title, y_multiplier_integer,
                                    wordcloud_title,
                                    True, False, True, False, 90, GUI_IO_util.labels_x_indented_coordinate,
                                    "Enter a preferred title for the wordcloud image.\n"
                                    "If left blank, the chart title will be automatically created from the input fiilename or input directory.")
 
-prefer_horizontal_checkbox = tk.Checkbutton(window, variable=prefer_horizontal_var,
+prefer_horizontal_checkbox = GUI_theme_util.create_checkbox(window, variable=prefer_horizontal_var,
                                                        onvalue=1, offvalue=0)
 
-prefer_horizontal_checkbox.config(text="Horizontal")
+prefer_horizontal_checkbox.configure(text="Horizontal")
 # place widget with hover-over info
 y_multiplier_integer = GUI_IO_util.placeWidget(window,GUI_IO_util.wordclouds_lowercase_pos, y_multiplier_integer,
                                    prefer_horizontal_checkbox,
@@ -321,25 +323,25 @@ prefer_horizontal_var.trace('w',warnUser)
 # font_list = wordclouds_util.get_font_list()
 
 font_var.set('Default')
-font_lb = tk.Label(window, text='Font')
+font_lb = GUI_theme_util.create_label(window, text='Font')
 # place widget with hover-over info
 y_multiplier_integer = GUI_IO_util.placeWidget(window,GUI_IO_util.wordclouds_collocation_pos, y_multiplier_integer,
                                    font_lb,
                                    True, False, True, False, 90, GUI_IO_util.wordclouds_font_lb,
                                    "Select the font you want to use in the wordclouds visualization; default font is the Adobe Droid Sans Mono font.")
 
-font = ttk.Combobox(window, width = 15, textvariable = font_var)
+font = GUI_theme_util.create_combobox(window, width = 15, textvariable = font_var)
 # font['values'] = font_list
 y_multiplier_integer=GUI_IO_util.placeWidget(window,GUI_IO_util.wordclouds_font_menu, y_multiplier_integer,font)
-# font.config(state='disabled')
+# font.configure(state='disabled')
 
 max_words_var=tk.StringVar()
 max_words_var.set(100)
 
-max_words_lb = tk.Label(window, text='Max no. of words')
+max_words_lb = GUI_theme_util.create_label(window, text='Max no. of words')
 y_multiplier_integer=GUI_IO_util.placeWidget(window,GUI_IO_util.labels_x_indented_coordinate, y_multiplier_integer,max_words_lb,True)
-max_words=tk.Entry(window, width=4,textvariable=max_words_var)
-max_words.config(state='normal')
+max_words=GUI_theme_util.create_entry(window, width=4,textvariable=max_words_var)
+max_words.configure(state='normal')
 # place widget with hover-over info
 y_multiplier_integer = GUI_IO_util.placeWidget(window,GUI_IO_util.wordclouds_max_words_number, y_multiplier_integer,
                                    max_words,
@@ -347,9 +349,9 @@ y_multiplier_integer = GUI_IO_util.placeWidget(window,GUI_IO_util.wordclouds_max
                                    "Enter the maximum number of words to be displayed on the wordclouds image.\nIncrease the number, if words are not displayed as expected.")
 
 lemmatize_var.set(1)
-lemmatize_checkbox = tk.Checkbutton(window, variable=lemmatize_var,
+lemmatize_checkbox = GUI_theme_util.create_checkbox(window, variable=lemmatize_var,
                                                        onvalue=1, offvalue=0)
-lemmatize_checkbox.config(text="Lemmas")
+lemmatize_checkbox.configure(text="Lemmas")
 # place widget with hover-over info
 y_multiplier_integer = GUI_IO_util.placeWidget(window,GUI_IO_util.wordclouds_lemmas_pos, y_multiplier_integer,
                                    lemmatize_checkbox,
@@ -357,10 +359,10 @@ y_multiplier_integer = GUI_IO_util.placeWidget(window,GUI_IO_util.wordclouds_lem
                                    "Untick the checkbox to NOT lemmatize words; tick the checkbox to lemmatize words in the corpus."
                                    "\nLemmatization is based on Stanza.\nLemmatization is NOT applied when a csv file is used in input.")
 
-stopwords_checkbox = tk.Checkbutton(window, variable=exclude_stopwords_var,
+stopwords_checkbox = GUI_theme_util.create_checkbox(window, variable=exclude_stopwords_var,
                                                        onvalue=1, offvalue=0)
 
-stopwords_checkbox.config(text="Stopwords")
+stopwords_checkbox.configure(text="Stopwords")
 # place widget with hover-over info
 y_multiplier_integer = GUI_IO_util.placeWidget(window,GUI_IO_util.wordclouds_stopwords_pos, y_multiplier_integer,
                                    stopwords_checkbox,
@@ -368,37 +370,37 @@ y_multiplier_integer = GUI_IO_util.placeWidget(window,GUI_IO_util.wordclouds_sto
                                    "Untick the checkbox to INCLUDE stopwords; tick the checkbox to EXCLUDE stopwords."
                                    "\nStopwords are provided by the Wordclouds package and printed in command line/terminal when stopwords are included.")
 
-punctuation_checkbox = tk.Checkbutton(window, variable=exclude_punctuation_var,
+punctuation_checkbox = GUI_theme_util.create_checkbox(window, variable=exclude_punctuation_var,
                                                        onvalue=1, offvalue=0)
 
-punctuation_checkbox.config(text="Punctuation")
+punctuation_checkbox.configure(text="Punctuation")
 # place widget with hover-over info
 y_multiplier_integer = GUI_IO_util.placeWidget(window,GUI_IO_util.wordclouds_punctuation_pos, y_multiplier_integer,
                                    punctuation_checkbox,
                                    True, False, True, False, 90, GUI_IO_util.wordclouds_punctuation_pos,
                                    "Untick the checkbox to EXCLUDE punctuation; tick the checkbox to INCLUDE punctuation.\nPunctuation is NOT applied when a csv file is used in input.")
 
-lowercase_checkbox = tk.Checkbutton(window, variable=lowercase_var,
+lowercase_checkbox = GUI_theme_util.create_checkbox(window, variable=lowercase_var,
                                                        onvalue=1, offvalue=0)
 
-lowercase_checkbox.config(text="Lowercase")
+lowercase_checkbox.configure(text="Lowercase")
 # place widget with hover-over info
 y_multiplier_integer = GUI_IO_util.placeWidget(window,GUI_IO_util.wordclouds_lowercase_pos, y_multiplier_integer,
                                    lowercase_checkbox,
                                    True, False, True, False, 90, GUI_IO_util.open_reminders_x_coordinate,
                                    "Untick the checkbox to NOT process corpus words in lowercase; tick the checkbox to process corpus words in lowercase")
 
-collocation_checkbox = tk.Checkbutton(window, variable=collocation_var,
+collocation_checkbox = GUI_theme_util.create_checkbox(window, variable=collocation_var,
                                                        onvalue=1, offvalue=0)
 
-collocation_checkbox.config(text="Collocation")
+collocation_checkbox.configure(text="Collocation")
 # place widget with hover-over info
 y_multiplier_integer = GUI_IO_util.placeWidget(window,GUI_IO_util.wordclouds_collocation_pos, y_multiplier_integer,
                                    collocation_checkbox,
                                    True, False, True, False, 90, GUI_IO_util.open_TIPS_x_coordinate,
                                    "Tick the checkbox to process multiple words together (e.g., standing up); untick the checkbox NOT to process multiple words together;\nTICKING THE COLLOCATION CHECKBOX MAY RESULT IN THE UNWANTED DUPLICATION OF SOME WORDS")
 
-differentPOS_differentColor_checkbox.config(text="Different colors by POS tags")
+differentPOS_differentColor_checkbox.configure(text="Different colors by POS tags")
 # place widget with hover-over info
 y_multiplier_integer = GUI_IO_util.placeWidget(window,GUI_IO_util.wordclouds_color_by_POS_tags, y_multiplier_integer,
                                    differentPOS_differentColor_checkbox,
@@ -412,10 +414,10 @@ if os.path.isfile(inputFilename.get()):
     if inputFilename.get().endswith('csv'):
         menu_values=IO_csv_util.get_csvfile_headers(inputFilename.get())
 
-prepare_image_checkbox = tk.Checkbutton(window, variable=prepare_image_var,
+prepare_image_checkbox = GUI_theme_util.create_checkbox(window, variable=prepare_image_var,
                                                        onvalue=1, offvalue=0)
 
-prepare_image_checkbox.config(text="Prepare image")
+prepare_image_checkbox.configure(text="Prepare image")
 # place widget with hover-over info
 y_multiplier_integer = GUI_IO_util.placeWidget(window,GUI_IO_util.labels_x_coordinate, y_multiplier_integer,
                                    prepare_image_checkbox,
@@ -423,7 +425,7 @@ y_multiplier_integer = GUI_IO_util.placeWidget(window,GUI_IO_util.labels_x_coord
                                    "Tick/untick the checkbox to open the web service Removebg to prepare an image for use in the Python wordclouds algorithm")
 
 # width=20,
-select_image_file_button=tk.Button(window, text='Select png image file',command=lambda: get_image(window,'Select INPUT png file', [("png files", "*.png")]))
+select_image_file_button=GUI_theme_util.create_button(window, text='Select png image file',command=lambda: get_image(window,'Select INPUT png file', [("png files", "*.png")]))
 # place widget with hover-over info
 y_multiplier_integer = GUI_IO_util.placeWidget(window,GUI_IO_util.labels_x_coordinate, y_multiplier_integer,
                                    select_image_file_button,
@@ -431,7 +433,7 @@ y_multiplier_integer = GUI_IO_util.placeWidget(window,GUI_IO_util.labels_x_coord
                                    "Click on the button to select the png image file")
 
 # setup a button to open Windows Explorer on open the png image file
-openImage_button = tk.Button(window, width=GUI_IO_util.open_file_directory_button_width, text='', state='disabled',
+openImage_button = GUI_theme_util.create_open_file_button(window, state='disabled',
                                  command=lambda: IO_files_util.openFile(window,
                                                                         selectedImage_var.get()))
 # the button widget has hover-over effects (no_hover_over_widget=False) and the info displayed is in text_info
@@ -439,13 +441,13 @@ openImage_button = tk.Button(window, width=GUI_IO_util.open_file_directory_butto
 y_multiplier_integer = GUI_IO_util.placeWidget(window,GUI_IO_util.wordclouds_openImage_button, y_multiplier_integer,
                                                openImage_button, True, False, True,False, 90, GUI_IO_util.wordclouds_openImage_button, "Open png image file")
 
-selectedImage=tk.Entry(window, width=GUI_IO_util.wordclouds_selectedImage_width,textvariable=selectedImage_var)
-selectedImage.config(state='disabled')
+selectedImage=GUI_theme_util.create_entry(window, width=GUI_IO_util.wordclouds_selectedImage_width,textvariable=selectedImage_var)
+selectedImage.configure(state='disabled')
 y_multiplier_integer=GUI_IO_util.placeWidget(window,GUI_IO_util.wordclouds_selectedImage_file_path, y_multiplier_integer,selectedImage, True)
 
 use_contour_only_var.set(1)
-use_contour_only_checkbox = tk.Checkbutton(window, variable=use_contour_only_var, onvalue=1, offvalue=0)
-use_contour_only_checkbox.config(text="Use image contour only")
+use_contour_only_checkbox = GUI_theme_util.create_checkbox(window, variable=use_contour_only_var, onvalue=1, offvalue=0)
+use_contour_only_checkbox.configure(text="Use image contour only")
 # place widget with hover-over info
 y_multiplier_integer = GUI_IO_util.placeWidget(window,GUI_IO_util.contour_only_pos, y_multiplier_integer,
                                    use_contour_only_checkbox,
@@ -462,8 +464,8 @@ def get_image(window,title,fileType):
 
 # labeling each group of words with separate colors"
 differentColumns_differentColor_var.set(0)
-differentColumns_differentColor_checkbox = tk.Checkbutton(window, variable=differentColumns_differentColor_var, onvalue=1, offvalue=0)
-differentColumns_differentColor_checkbox.config(text="Use different colors for different columns (csv file as INPUT)")
+differentColumns_differentColor_checkbox = GUI_theme_util.create_checkbox(window, variable=differentColumns_differentColor_var, onvalue=1, offvalue=0)
+differentColumns_differentColor_checkbox.configure(text="Use different colors for different columns (csv file as INPUT)")
 # place widget with hover-over info
 y_multiplier_integer = GUI_IO_util.placeWidget(window,GUI_IO_util.labels_x_coordinate, y_multiplier_integer,
                                    differentColumns_differentColor_checkbox,
@@ -483,13 +485,12 @@ if os.path.isfile(inputFilename.get()):
     if inputFilename.get().endswith('csv'):
         menu_values=IO_csv_util.get_csvfile_headers(inputFilename.get())
 
-field_lb = tk.Label(window, text='Select csv field')
+field_lb = GUI_theme_util.create_label(window, text='Select csv field')
 y_multiplier_integer=GUI_IO_util.placeWidget(window,GUI_IO_util.labels_x_indented_coordinate,y_multiplier_integer,field_lb,True)
 
-if menu_values!='':
-    csv_field_menu = tk.OptionMenu(window, csv_field_var, *menu_values)
-else:
-    csv_field_menu = tk.OptionMenu(window, csv_field_var, menu_values)
+# CTkOptionMenu takes its items as a list, so the legacy empty/non-empty varargs branch collapses.
+csv_field_menu = GUI_theme_util.create_option_menu(window, variable=csv_field_var,
+                                                   values=list(menu_values) if menu_values else [''])
 csv_field_menu.configure(state='disabled')
 # place widget with hover-over info
 y_multiplier_integer = GUI_IO_util.placeWidget(window,GUI_IO_util.wordclouds_select_csv_field, y_multiplier_integer,
@@ -506,27 +507,27 @@ y_multiplier_integer = GUI_IO_util.placeWidget(window,GUI_IO_util.wordclouds_sel
 #                 mb.showwarning(title='Input file error', message='The Python 3 wordclouds algorithm expects in input a csv type file.\n\nPlease, select a csv input file and try again.')
 #                 # differentColumns_differentColors_var.set(0)
 #                 return
-#             differentColumns_differentColor_checkbox.config(state='normal')
+#             differentColumns_differentColor_checkbox.configure(state='normal')
 #             csv_field_menu.configure(state='normal')
 #
 #     else:
-#         differentColumns_differentColor_checkbox.config(state='disabled')
+#         differentColumns_differentColor_checkbox.configure(state='disabled')
 #         csv_field_menu.configure(state='disabled')
 # differentColumns_differentColor_var.trace('w',activateCsvOptions)
 #
 # activateCsvOptions()
 
 color_var.set(0)
-color_checkbox = tk.Checkbutton(window, text='Color ', state='disabled',variable=color_var, onvalue=1, offvalue=0)
+color_checkbox = GUI_theme_util.create_checkbox(window, text='Color ', state='disabled',variable=color_var, onvalue=1, offvalue=0)
 # place widget with hover-over info
 y_multiplier_integer = GUI_IO_util.placeWidget(window,GUI_IO_util.wordclouds_color_checkbox_pos, y_multiplier_integer,
                                    color_checkbox,
                                    True, False, True, False, 90, GUI_IO_util.wordclouds_color_checkbox_pos,
                                    "Tick the 'Color' checkbox to open the RGB color pallette to select the desired color for your selected csv field")
 
-color_lb = tk.Label(window, text='RGB color code ')
+color_lb = GUI_theme_util.create_label(window, text='RGB color code ')
 y_multiplier_integer=GUI_IO_util.placeWidget(window,GUI_IO_util.wordclouds_RGB_lb,y_multiplier_integer,color_lb,True)
-color_entry = tk.Entry(window, width=10, textvariable=color_style_var)
+color_entry = GUI_theme_util.create_entry(window, width=10, textvariable=color_style_var)
 color_entry.configure(state='disabled')
 y_multiplier_integer=GUI_IO_util.placeWidget(window,GUI_IO_util.wordclouds_RGB,y_multiplier_integer,color_entry,True)
 
@@ -537,8 +538,6 @@ def activate_color_palette(*args):
     # PIL being the commmon module for both packages, you need to check for PIL and trap PIL to tell the user to install pillow
     from tkcolorpicker import askcolor
     if color_var.get()==1:
-        style = ttk.Style(window)
-        style.theme_use('clam')
         color_list = askcolor((255, 255, 0), window)
         color_style = color_list[0]
         color_style_var.set(color_style)
@@ -550,10 +549,10 @@ def update_csvFields():
     csv_field_menu.configure(state="normal")
     color_var.set(0)
 
-add_button = tk.Button(window, text='+', width=GUI_IO_util.add_button_width,height=1,state='disabled',command=lambda: update_csvFields())
+add_button = GUI_theme_util.create_button(window, text='+', width=GUI_IO_util.add_button_width,height=1,state='disabled',command=lambda: update_csvFields())
 y_multiplier_integer=GUI_IO_util.placeWidget(window,GUI_IO_util.wordclouds_add_button,y_multiplier_integer,add_button, True)
 
-reset_button = tk.Button(window, text='Reset ', width=GUI_IO_util.reset_button_width, height=1,state='disabled',command=lambda: clear_field_color_list())
+reset_button = GUI_theme_util.create_button(window, text='Reset ', width=GUI_IO_util.reset_button_width, height=1,state='disabled',command=lambda: clear_field_color_list())
 y_multiplier_integer=GUI_IO_util.placeWidget(window,GUI_IO_util.wordclouds_reset_button,y_multiplier_integer,reset_button,True)
 
 def showList():
@@ -562,13 +561,13 @@ def showList():
     else:
         mb.showwarning(title='Warning', message='The currently selected combination of csv fields and colors is:\n\n' + ','.join(csvField_color_list) + '\n\nPlease, press the RESET button (or ESCape) to start fresh.')
 
-show_columns_button = tk.Button(window, text='Show',width=GUI_IO_util.show_button_width, height=1,state='disabled',command=lambda: showList())
+show_columns_button = GUI_theme_util.create_button(window, text='Show',width=GUI_IO_util.show_button_width, height=1,state='disabled',command=lambda: showList())
 y_multiplier_integer=GUI_IO_util.placeWidget(window,GUI_IO_util.wordclouds_show_button,y_multiplier_integer,show_columns_button)
 
 def activateCsvField(*args):
     if csv_field_var.get()!='':
         color_checkbox.configure(state='normal')
-        state = str(csv_field_menu['state'])
+        state = str(csv_field_menu.cget('state'))
         if state != 'disabled':
             if csv_field_var.get() in csvField_color_list:
                 mb.showwarning(title='Warning', message='The selected csv field value, ' + csv_field_var.get() + ', has already been selected.\n\nPlease, select a different value. You can display all selected values by clicking on SHOW.')
@@ -595,40 +594,40 @@ def activate_Python_options(*args):
     if not 'Python' in wordclouds_var.get():
         selectedImage_var.set('')
         use_contour_only_var.set(1)
-        use_contour_only_checkbox.config(state='disabled')
-        prepare_image_checkbox.config(state='disabled')
-        select_image_file_button.config(state='disabled')
-        openImage_button.config(state='disabled')
-        differentColumns_differentColor_checkbox.config(state='disabled')
-        prefer_horizontal_checkbox.config(state='disabled')
-        font.config(state='disabled')
-        max_words.config(state='disabled')
-        lemmatize_checkbox.config(state='disabled')
-        stopwords_checkbox.config(state='disabled')
-        punctuation_checkbox.config(state='disabled')
-        lowercase_checkbox.config(state='disabled')
-        collocation_checkbox.config(state='disabled')
-        differentPOS_differentColor_checkbox.config(state='disabled')
+        use_contour_only_checkbox.configure(state='disabled')
+        prepare_image_checkbox.configure(state='disabled')
+        select_image_file_button.configure(state='disabled')
+        openImage_button.configure(state='disabled')
+        differentColumns_differentColor_checkbox.configure(state='disabled')
+        prefer_horizontal_checkbox.configure(state='disabled')
+        font.configure(state='disabled')
+        max_words.configure(state='disabled')
+        lemmatize_checkbox.configure(state='disabled')
+        stopwords_checkbox.configure(state='disabled')
+        punctuation_checkbox.configure(state='disabled')
+        lowercase_checkbox.configure(state='disabled')
+        collocation_checkbox.configure(state='disabled')
+        differentPOS_differentColor_checkbox.configure(state='disabled')
     else:
-        differentColumns_differentColor_checkbox.config(state='normal')
-        prefer_horizontal_checkbox.config(state='normal')
-        font.config(state='normal')
-        max_words.config(state='normal')
-        lemmatize_checkbox.config(state='normal')
-        stopwords_checkbox.config(state='normal')
-        punctuation_checkbox.config(state='normal')
-        lowercase_checkbox.config(state='normal')
-        collocation_checkbox.config(state='normal')
-        differentPOS_differentColor_checkbox.config(state='normal')
+        differentColumns_differentColor_checkbox.configure(state='normal')
+        prefer_horizontal_checkbox.configure(state='normal')
+        font.configure(state='normal')
+        max_words.configure(state='normal')
+        lemmatize_checkbox.configure(state='normal')
+        stopwords_checkbox.configure(state='normal')
+        punctuation_checkbox.configure(state='normal')
+        lowercase_checkbox.configure(state='normal')
+        collocation_checkbox.configure(state='normal')
+        differentPOS_differentColor_checkbox.configure(state='normal')
         exclude_stopwords_var.set(1)
         exclude_punctuation_var.set(1)
         lowercase_var.set(1)
         collocation_var.set(0)
 
-        prepare_image_checkbox.config(state='normal')
-        select_image_file_button.config(state='normal')
-        openImage_button.config(state='normal')
-        use_contour_only_checkbox.config(state='normal')
+        prepare_image_checkbox.configure(state='normal')
+        select_image_file_button.configure(state='normal')
+        openImage_button.configure(state='normal')
+        use_contour_only_checkbox.configure(state='normal')
 
 wordclouds_var.trace('w',activate_Python_options)
 activate_Python_options()
@@ -640,21 +639,18 @@ def changed_filename(*args):
     if os.path.isfile(inputFilename.get()):
         if not inputFilename.get().endswith('csv'):
             differentColumns_differentColor_var.set(0)
-            differentColumns_differentColor_checkbox.config(state='disabled')
+            differentColumns_differentColor_checkbox.configure(state='disabled')
             csv_field_menu.configure(state='disabled')
             return
         else:
-            differentColumns_differentColor_checkbox.config(state='normal')
+            differentColumns_differentColor_checkbox.configure(state='normal')
             csv_field_menu.configure(state='normal')
             menu_values = IO_csv_util.get_csvfile_headers(inputFilename.get())
-            m = csv_field_menu["menu"]
-            m.delete(0, "end")
-            for s in menu_values:
-                m.add_command(label=s, command=lambda value=s: csv_field_var.set(value))
+            GUI_theme_util.set_values(csv_field_menu, menu_values)
             # activateCsvOptions()
     else:
         differentColumns_differentColor_var.set(0)
-        differentColumns_differentColor_checkbox.config(state='disabled')
+        differentColumns_differentColor_checkbox.configure(state='disabled')
         csv_field_menu.configure(state='disabled')
         return
 inputFilename.trace('w',changed_filename)
@@ -663,22 +659,22 @@ input_main_dir_path.trace('w',changed_filename)
 changed_filename()
 
 doNotCreateIntermediateFiles_var.set(1)
-doNotCreateIntermediateFiles_checkbox = tk.Checkbutton(window, variable=doNotCreateIntermediateFiles_var, onvalue=1, offvalue=0)
-doNotCreateIntermediateFiles_checkbox.config(text="Do NOT produce intermediate word cloud files when processing all txt files in a directory")
+doNotCreateIntermediateFiles_checkbox = GUI_theme_util.create_checkbox(window, variable=doNotCreateIntermediateFiles_var, onvalue=1, offvalue=0)
+doNotCreateIntermediateFiles_checkbox.configure(text="Do NOT produce intermediate word cloud files when processing all txt files in a directory")
 y_multiplier_integer=GUI_IO_util.placeWidget(window,GUI_IO_util.labels_x_coordinate,y_multiplier_integer,doNotCreateIntermediateFiles_checkbox)
 
 def changeLabel_nomin(*args):
     if doNotCreateIntermediateFiles_var.get()==1:
-        doNotCreateIntermediateFiles_checkbox.config(text="Do NOT produce intermediate word cloud files when processing all txt files in a directory")
+        doNotCreateIntermediateFiles_checkbox.configure(text="Do NOT produce intermediate word cloud files when processing all txt files in a directory")
     else:
-        doNotCreateIntermediateFiles_checkbox.config(text="Produce intermediate word cloud files when processing all txt files in a directory")
+        doNotCreateIntermediateFiles_checkbox.configure(text="Produce intermediate word cloud files when processing all txt files in a directory")
 doNotCreateIntermediateFiles_var.trace('w',changeLabel_nomin)
 
 def turnOff_doNotCreateIntermediateFiles_checkbox(*args):
     if len(input_main_dir_path.get())>0:
-        doNotCreateIntermediateFiles_checkbox.config(state='normal')
+        doNotCreateIntermediateFiles_checkbox.configure(state='normal')
     else:
-        doNotCreateIntermediateFiles_checkbox.config(state='disabled')
+        doNotCreateIntermediateFiles_checkbox.configure(state='disabled')
 input_main_dir_path.trace('w',turnOff_doNotCreateIntermediateFiles_checkbox)
 
 videos_lookup = {'Wordcloud 1':'https://youtu.be/CfRV9V7-OCM', 'Wordcloud 2':'https://youtu.be/5Q-AvG45rHY'}
@@ -749,6 +745,8 @@ reminders_util.checkReminder(scriptName, title, message)
 import wordclouds_util
 import run_script_util
 font_list = wordclouds_util.get_font_list()
-font['values'] = font_list
+# NOT font['values'] = font_list: tkinter's __setitem__ forwards the dict as CTkComboBox.configure's
+# first positional arg (require_redraw), so the legacy form silently sets nothing under CTk.
+GUI_theme_util.set_values(font, font_list)
 
 GUI_util.window.mainloop()

--- a/tests/ctk_bundle_smoke.py
+++ b/tests/ctk_bundle_smoke.py
@@ -1,0 +1,113 @@
+"""Phase 0 bundle smoke test for the CustomTkinter migration (docs/CustomTkinter-Migration-Plan.md).
+
+GO / NO-GO gate: does CustomTkinter -- and specifically the PIL.ImageTk path used by CTkImage --
+actually work under the interpreter that ships in the NLP Suite installer (python-build-standalone)?
+That interpreter has historically broken Tk-adjacent image handling: it is the reason
+GUI_util.tk_image_from_pil exists, and it is what crashed the matplotlib 'TkAgg' backend (fixed by
+falling back to 'Agg').
+
+RESULT (2026-07-15, macOS aarch64, cpython-3.10.15 python-build-standalone): raw CTkImage FAILS
+under the bundle exactly as predicted -- `TypeError: bad argument type for built-in operation` from
+PIL.ImageTk. The fix is ctk_bundle_util.patch_ctk_image_for_bundle(), which routes CTkImage's Tk
+image construction through the same base64-PNG path as GUI_util.tk_image_from_pil. This test applies
+that patch and verifies CTkImage then works, so the gate now checks the SHIPPING approach (patched).
+Without the patch the CTkImage check fails -- see docs/CustomTkinter-Migration-Plan.md §5.1.
+
+IMPORTANT: run this INSIDE the frozen bundle / with the BUNDLED interpreter (python-build-standalone),
+not just a dev Anaconda env -- a dev env passing tells you nothing about the bundle. It needs a real
+display (a GUI session), so it is NOT a headless pytest unit test (the filename has no test_ prefix /
+_test suffix on purpose, so pytest won't collect it).
+
+Usage:  <bundled-python> tests/ctk_bundle_smoke.py
+Exit code 0 = PASS (all checks), non-zero = FAIL. Prints a per-check report.
+"""
+# Standalone runtime probe: customtkinter/ctk_bundle_util are optional and loaded via a runtime
+# sys.path insert, and _ctk is a deliberately None-initialised module global. None of that is
+# statically resolvable, so scope off the two Pyright rules it trips.
+# pyright: reportMissingImports=false, reportOptionalMemberAccess=false
+import os
+import sys
+
+# Import the production shim from src/ without importing GUI_util (which builds a Tk root at import).
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'src'))
+
+_results = []
+_root = None
+_ctk = None
+
+
+def _check(name, fn):
+    try:
+        fn()
+        _results.append((name, True, ''))
+        print('PASS  ' + name)
+    except BaseException as e:   # BaseException: a Tcl/Tk failure can surface oddly
+        _results.append((name, False, repr(e)))
+        print('FAIL  ' + name + '  ->  ' + repr(e))
+
+
+def _import_and_root():
+    global _root, _ctk
+    import customtkinter as ctk
+    from ctk_bundle_util import patch_ctk_image_for_bundle
+    if not patch_ctk_image_for_bundle():   # apply the bundle ImageTk workaround before any CTkImage
+        raise RuntimeError('patch_ctk_image_for_bundle() reported CustomTkinter not importable')
+    _ctk = ctk
+    ctk.set_appearance_mode('light')
+    _root = ctk.CTk()
+    _root.geometry('320x220')
+    _root.update()   # force the first render pass
+
+
+def _basic_widgets():
+    _ctk.CTkLabel(_root, text='smoke').pack()
+    _ctk.CTkButton(_root, text='button').pack()
+    om = _ctk.CTkOptionMenu(_root, values=['alpha', 'beta'])
+    om.pack()
+    om.set('beta')                       # OptionMenu repopulation path (a known migration gotcha)
+    _ctk.CTkFrame(_root).pack()
+    _root.update()
+
+
+def _ctk_image():
+    # THE risk: CTkImage -> PIL.ImageTk, which python-build-standalone breaks. Passes only because
+    # patch_ctk_image_for_bundle() (applied in _import_and_root) reroutes it through base64 PNG.
+    from PIL import Image
+    img = Image.new('RGB', (16, 16), (200, 30, 30))
+    cimg = _ctk.CTkImage(light_image=img, dark_image=img, size=(16, 16))
+    _ctk.CTkLabel(_root, text='', image=cimg).pack()
+    _root.update()
+
+
+def _appearance_toggle():
+    _ctk.set_appearance_mode('dark')
+    _root.update()
+    _ctk.set_appearance_mode('light')
+    _root.update()
+
+
+def _teardown():
+    if _root is not None:
+        _root.destroy()
+
+
+def main():
+    print('CustomTkinter bundle smoke test — interpreter: ' + sys.version.split()[0])
+    _check('import customtkinter + create CTk root', _import_and_root)
+    if _root is not None:
+        _check('basic CTk widgets render (Label/Button/OptionMenu/Frame)', _basic_widgets)
+        _check('CTkImage (patched: base64-PNG path, the python-build-standalone risk)', _ctk_image)
+        _check('appearance mode light<->dark toggle', _appearance_toggle)
+        _check('teardown (destroy root)', _teardown)
+    ok = bool(_results) and all(p for _, p, _ in _results)
+    print('\n=== Phase 0 CustomTkinter bundle smoke test: ' + ('PASS' if ok else 'FAIL') + ' ===')
+    if not ok:
+        print('Failing checks:')
+        for name, passed, err in _results:
+            if not passed:
+                print('  - ' + name + ': ' + err)
+    return 0 if ok else 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/gui_smoke.py
+++ b/tests/gui_smoke.py
@@ -146,6 +146,88 @@ _STUB_ROOTS = {'stanza','spacy','nltk','torch','torchvision','transformers','sen
                'spacy_langdetect','spacytextblob','contractions','unidecode','chardet','pdfplumber',
                'docx','fitz','striprtf','pyLDAvis','little_mallet_wrapper','tkcolorpicker','tkinterdnd2',
                'pymupdf','pdf2image','pytesseract','wikipediaapi','geotext','reverse_geocoder'}
+# ---------- fake customtkinter ----------
+# customtkinter (CTk migration, GUI_theme_util) can't be imported for real here: its widget classes
+# subclass real tkinter.Frame/tkinter.Tk AT IMPORT TIME (e.g. CTkBaseClass(tkinter.Frame, ...)),
+# which the fake tkinter's `_rec` function stand-ins can't satisfy (you can't subclass a function),
+# and constructing a real CTk widget needs a live Tk root this headless harness deliberately lacks.
+#
+# It is stubbed HAND-WRITTEN rather than as a MagicMock tree (which is what it was through Phase 1).
+# A MagicMock answers every call and every subscript, so it silently absorbs exactly the breakages a
+# tk->CTk conversion introduces. All three bugs found converting the first pilot (wordclouds_main)
+# passed a MagicMock-stubbed smoke run untouched:
+#   * `widget.config(...)`      -- real CTk RAISES AttributeError ("use 'configure' instead").
+#   * `widget['state']`         -- real CTk resolves __getitem__ against the underlying tk frame,
+#                                  which has no such option -> TclError.
+#   * `widget['values'] = [...]` -- tkinter's __setitem__ passes the dict as CTkComboBox.configure's
+#                                  first POSITIONAL arg (require_redraw), so it SILENTLY no-ops.
+# So the stub below reproduces those three contracts and nothing else it doesn't have to. It also
+# records `text=` into _texts like `_rec` does, which keeps GOLDEN label checks working for GUIs once
+# their widgets move to GUI_theme_util factories.
+class _CTkWidget(object):
+    # The parameters are spelled out (rather than a bare **k) because GUI_theme_util.translate_kwargs
+    # filters translated kwargs against `inspect.signature(cls.__init__)`: a `(*a, **k)` stub reports
+    # an EMPTY accepted-parameter set, so every kwarg -- `text` included -- would be dropped and the
+    # GOLDEN label checks would silently record nothing. This list is deliberately permissive; the
+    # exact per-class kwarg filtering is covered against the REAL CTk classes by the pytest suite.
+    def __init__(self, master=None, text=None, width=None, height=None, state=None, command=None,
+                 variable=None, textvariable=None, values=None, font=None, image=None, anchor=None,
+                 corner_radius=None, border_width=None, placeholder_text=None, fg_color=None,
+                 hover_color=None, text_color=None, button_color=None, button_hover_color=None,
+                 checkbox_width=None, checkbox_height=None, onvalue=None, offvalue=None,
+                 from_=None, to=None, orientation=None, number_of_steps=None, **k):
+        self._opts = dict(k)
+        self._opts.update({key: val for key, val in (
+            ('text', text), ('state', state), ('values', values), ('width', width),
+            ('height', height), ('variable', variable), ('textvariable', textvariable),
+        ) if val is not None})
+        if text is not None:
+            try: _texts.append(str(text))
+            except Exception: pass
+
+    def config(self, *a, **k):
+        # Mirrors customtkinter.CTkBaseClass.config, which exists only to raise.
+        raise AttributeError("'config' is not implemented for CTk widgets. "
+                             "For consistency, always use 'configure' instead.")
+
+    def configure(self, require_redraw=False, **k):
+        if not isinstance(require_redraw, bool):
+            # The `widget['x'] = y` silent no-op: tkinter's __setitem__ lands the option dict here.
+            raise TypeError("CTk configure() got a non-bool as require_redraw (%r) -- this is the "
+                            "`widget[key] = value` idiom, which silently no-ops on CTk widgets. "
+                            "Use widget.configure(key=value) or GUI_theme_util.set_values()."
+                            % (require_redraw,))
+        t = k.get('text')
+        if t is not None:
+            try: _texts.append(str(t))
+            except Exception: pass
+        self._opts.update(k)
+
+    def cget(self, key):
+        return self._opts.get(key, '')
+
+    def __getitem__(self, key):
+        raise TypeError("CTk widgets do not support widget[%r] lookup (it resolves against the "
+                        "underlying tk frame and raises TclError). Use widget.cget(%r)." % (key, key))
+
+    def __setitem__(self, key, value):
+        raise TypeError("CTk widgets do not support widget[%r] = ... (it silently no-ops). "
+                        "Use widget.configure(%s=...) or GUI_theme_util.set_values()." % (key, key))
+
+    def __getattr__(self, _n):
+        return MagicMock()
+
+_ctk = types.ModuleType('customtkinter')
+for _n in ('CTk','CTkToplevel','CTkFrame','CTkScrollableFrame','CTkLabel','CTkButton','CTkEntry',
+           'CTkCheckBox','CTkOptionMenu','CTkComboBox','CTkSlider','CTkSwitch','CTkTextbox',
+           'CTkRadioButton','CTkProgressBar','CTkSegmentedButton','CTkTabview','CTkImage','CTkFont',
+           'CTkCanvas','CTkScrollbar'):
+    setattr(_ctk, _n, type(_n, (_CTkWidget,), {}))
+for _fn in ('set_appearance_mode','set_default_color_theme','set_widget_scaling',
+            'deactivate_automatic_dpi_awareness','get_appearance_mode'):
+    setattr(_ctk, _fn, lambda *a, **k: None)
+_ctk.__version__ = '6.0.0'
+sys.modules['customtkinter'] = _ctk
 
 
 class _StubLoader(importlib.abc.Loader):

--- a/tests/test_gui_theme_util.py
+++ b/tests/test_gui_theme_util.py
@@ -188,3 +188,48 @@ def test_accent_constants_are_the_brand_red_and_distinct_from_muted():
     # accent (available, red) and muted (nothing available, grey) must be visibly different cues.
     assert gtu._ACCENT_FG != gtu._MUTED_FG
     assert gtu.NLP_SUITE_ACCENT != gtu._MUTED_FG
+
+
+# ── the CTk widget contracts that broke legacy tk idioms during the Phase 2 pilot ──
+# These pin behaviours of the REAL customtkinter that a tk->CTk conversion trips over, and that
+# tests/gui_smoke.py's hand-written CTk stub deliberately reproduces. If a CustomTkinter upgrade
+# changes any of them, these fail here -- telling us the smoke stub has drifted from reality --
+# instead of the smoke suite quietly going blind to a whole class of conversion bug.
+class TestCTkLegacyIdiomContracts:
+    def test_config_raises_so_conversions_must_use_configure(self):
+        # ~50 legacy .config(...) call sites per GUI; CTk implements config() only to raise.
+        with pytest.raises(AttributeError, match="configure"):
+            ctk.CTkButton.config(object(), state="disabled")
+
+    def test_configure_first_positional_is_require_redraw(self):
+        # This is why `widget['values'] = [...]` SILENTLY no-ops instead of raising: tkinter's
+        # __setitem__ does configure({key: value}), landing the dict on require_redraw.
+        import inspect
+
+        for cls in (ctk.CTkComboBox, ctk.CTkOptionMenu):
+            params = list(inspect.signature(cls.configure).parameters)
+            assert params[1] == "require_redraw", f"{cls.__name__}.configure signature changed"
+
+    def test_set_values_is_the_supported_repopulation_path(self):
+        # The positive counterpart: configure(values=...) is a real keyword on both menu classes.
+        import inspect
+
+        for cls in (ctk.CTkComboBox, ctk.CTkOptionMenu):
+            assert "values" in inspect.signature(cls.__init__).parameters
+
+
+# ── entry width chrome allowance (Phase 2 pilot: a 4-char box clipped "100" to "10C") ──
+class TestEntryWidthPadding:
+    def test_translate_kwargs_adds_width_padding(self):
+        out = gtu.translate_kwargs(ctk.CTkEntry, {"width": 4}, height_is_lines=False, width_padding=14)
+        assert out["width"] == gtu.char_width_to_px(4) + 14
+
+    def test_width_padding_defaults_to_zero_for_other_widgets(self):
+        # Only entries opt in; a button's width translation must be unchanged.
+        assert gtu.translate_kwargs(ctk.CTkButton, {"width": 4})["width"] == gtu.char_width_to_px(4)
+
+    def test_padding_is_not_applied_to_a_dropped_width(self):
+        # A non-positive/non-numeric width still drops out entirely rather than becoming bare padding.
+        assert "width" not in gtu.translate_kwargs(
+            ctk.CTkEntry, {"width": 0}, height_is_lines=False, width_padding=14
+        )

--- a/tests/test_gui_theme_util.py
+++ b/tests/test_gui_theme_util.py
@@ -1,0 +1,190 @@
+"""Unit tests for GUI_theme_util -- the CustomTkinter compatibility layer (CTk migration Phase 1).
+
+Covers the *pure* logic: the character/line -> pixel width translation, the tk-kwargs -> CTk-kwargs
+translation (validated against the real CustomTkinter 6.0.0 class signatures via introspection, no
+display needed), and the ``set_values`` menu-repopulation helper. Widget construction and the
+ToolTip surface need a live Tk display and are exercised by tests/gui_smoke.py, not here.
+
+customtkinter is import-skipped so the suite still collects on a box without it installed.
+"""
+
+import pytest
+
+ctk = pytest.importorskip("customtkinter")
+
+import GUI_theme_util as gtu  # noqa: E402  (import after importorskip on purpose)
+
+
+# ── char_width_to_px ─────────────────────────────────────────────────────────
+class TestCharWidthToPx:
+    def test_basic_chars_to_pixels(self):
+        assert gtu.char_width_to_px(10) == 10 * gtu._PX_PER_CHAR
+
+    def test_custom_px_per_char_and_padding(self):
+        assert gtu.char_width_to_px(5, px_per_char=10, padding=4) == 54
+
+    @pytest.mark.parametrize("bad", [0, -3, None, "", "abc"])
+    def test_missing_or_nonpositive_returns_none(self, bad):
+        assert gtu.char_width_to_px(bad) is None
+
+    def test_large_char_width_still_multiplied(self):
+        # No magnitude cutoff: a wide legacy entry (e.g. a 115-char file-path field) must be scaled
+        # to pixels like any other char width, not passed through as ~115px. Pixel-holding callers
+        # opt out via width_is_chars=False in translate_kwargs, not via a magic size threshold.
+        assert gtu.char_width_to_px(115) == 115 * gtu._PX_PER_CHAR
+
+    def test_numeric_string_is_accepted(self):
+        assert gtu.char_width_to_px("12") == 12 * gtu._PX_PER_CHAR
+
+
+# ── line_height_to_px ────────────────────────────────────────────────────────
+class TestLineHeightToPx:
+    def test_single_line_floors_to_min_widget_px(self):
+        assert gtu.line_height_to_px(1) == gtu._MIN_WIDGET_PX
+
+    def test_two_line_button_taller_than_min(self):
+        assert gtu.line_height_to_px(2) == max(gtu._MIN_WIDGET_PX, 2 * gtu._PX_PER_LINE)
+
+    @pytest.mark.parametrize("bad", [0, -1, None, "x"])
+    def test_missing_or_nonpositive_returns_none(self, bad):
+        assert gtu.line_height_to_px(bad) is None
+
+    def test_large_line_count_still_multiplied(self):
+        # Same rule as width: no magnitude cutoff. Pixel-holding heights bypass via
+        # height_is_lines=False (see test_entry_height_not_line_translated_when_flag_off).
+        assert gtu.line_height_to_px(20) == max(gtu._MIN_WIDGET_PX, 20 * gtu._PX_PER_LINE)
+
+
+# ── translate_kwargs (against real CTk 6.0.0 signatures) ─────────────────────
+class TestTranslateKwargs:
+    def test_foreground_and_fg_rename_to_text_color(self):
+        assert gtu.translate_kwargs(ctk.CTkButton, {"foreground": "red"}) == {"text_color": "red"}
+        assert gtu.translate_kwargs(ctk.CTkButton, {"fg": "red"}) == {"text_color": "red"}
+
+    def test_width_translated_to_pixels(self):
+        out = gtu.translate_kwargs(ctk.CTkEntry, {"width": 30})
+        assert out == {"width": 30 * gtu._PX_PER_CHAR}
+
+    def test_height_translated_to_pixels(self):
+        out = gtu.translate_kwargs(ctk.CTkButton, {"height": 2})
+        assert out["height"] == max(gtu._MIN_WIDGET_PX, 2 * gtu._PX_PER_LINE)
+
+    def test_entry_height_not_line_translated_when_flag_off(self):
+        # create_entry passes height_is_lines=False; a raw pixel height must survive unchanged.
+        out = gtu.translate_kwargs(ctk.CTkEntry, {"height": 40}, height_is_lines=False)
+        assert out["height"] == 40
+
+    def test_width_not_char_translated_when_flag_off(self):
+        # The pixel escape hatch: a CTk-aware caller passes width_is_chars=False and its raw pixel
+        # width must survive unmultiplied (this replaces the old magnitude-guess passthrough).
+        out = gtu.translate_kwargs(ctk.CTkEntry, {"width": 920}, width_is_chars=False)
+        assert out["width"] == 920
+
+    def test_zero_width_is_dropped_not_zeroed(self):
+        # width<=0 -> None -> drop, so CTk keeps its own default sizing rather than a 0px widget.
+        assert "width" not in gtu.translate_kwargs(ctk.CTkButton, {"width": 0})
+
+    def test_native_tk_chrome_dropped(self):
+        out = gtu.translate_kwargs(
+            ctk.CTkButton,
+            {
+                "relief": "raised",
+                "bd": 2,
+                "borderwidth": 2,
+                "bg": "white",
+                "highlightthickness": 0,
+                "activebackground": "gray",
+            },
+        )
+        assert out == {}
+
+    def test_unsupported_ctk_kwarg_dropped(self):
+        # CTk 6.0.0 CTkLabel has no `justify`; it must be dropped, not passed to the constructor.
+        assert "justify" not in gtu.translate_kwargs(ctk.CTkLabel, {"justify": "left"})
+        # ...but CTkComboBox *does* accept justify, so there it survives.
+        assert gtu.translate_kwargs(ctk.CTkComboBox, {"justify": "left"}) == {"justify": "left"}
+
+    def test_accepted_passthrough_preserved(self):
+        out = gtu.translate_kwargs(ctk.CTkButton, {"text": "RUN", "state": "disabled"})
+        assert out == {"text": "RUN", "state": "disabled"}
+
+    def test_text_color_wins_over_dropped_bg(self):
+        out = gtu.translate_kwargs(ctk.CTkButton, {"foreground": "red", "bg": "white"})
+        assert out == {"text_color": "red"}
+
+
+# ── set_values ───────────────────────────────────────────────────────────────
+class _FakeMenu:
+    def __init__(self):
+        self.configured = None
+        self.selected = None
+
+    def configure(self, **kwargs):
+        self.configured = kwargs
+
+    def set(self, value):
+        self.selected = value
+
+
+class TestSetValues:
+    def test_configures_values_and_returns_list(self):
+        w = _FakeMenu()
+        result = gtu.set_values(w, ("a", "b", "c"))
+        assert w.configured == {"values": ["a", "b", "c"]}
+        assert result == ["a", "b", "c"]
+        assert w.selected is None  # no default -> selection untouched
+
+    def test_default_selects_item(self):
+        w = _FakeMenu()
+        gtu.set_values(w, ["x", "y"], default="x")
+        assert w.selected == "x"
+
+
+# ── _accepted_params sanity ──────────────────────────────────────────────────
+def test_accepted_params_excludes_self_and_varargs():
+    params = gtu._accepted_params(ctk.CTkButton)
+    assert "self" not in params and "master" not in params
+    assert "text" in params and "command" in params
+
+
+# ── the theme JSON loads, and the default fill is NEUTRAL (regression) ─────────
+# Two things this guards:
+#   1. CTk's load_theme requires every top-level key to be a dict (it does theme[key].keys()); a
+#      stray "_comment" string key raised AttributeError and silently fell back to CTk's blue theme,
+#      shipping the whole suite in blue. We confirm the file's own colors reached ThemeManager.
+#   2. The default widget fill must be NEUTRAL grey, not the brand red -- red is a *signal* opted
+#      into via accent=True, never the default (the solid-red first cut was reverted; see plan §0).
+_CTK_BLUE_FALLBACK = {"#3B8ED0", "#1F6AA5"}  # CTk's stock "blue" CTkButton fg -- the bug's fingerprint
+
+
+def test_theme_json_loads_neutral_default_not_blue_fallback():
+    import json
+    import os
+
+    theme_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "src", "nlp_suite_theme.json")
+    assert os.path.isfile(theme_path), "nlp_suite_theme.json must ship in src/"
+
+    # Every top-level value must be a dict, or CTk's load_theme raises on theme[key].keys().
+    data = json.loads(open(theme_path, encoding="utf-8").read())
+    non_dict = [k for k, v in data.items() if not isinstance(v, dict)]
+    assert not non_dict, f"top-level theme keys must all be dicts; offenders: {non_dict}"
+
+    # Load for real through CTk and confirm the FILE's colors reached ThemeManager (not blue fallback).
+    ctk.set_default_color_theme(theme_path)
+    from customtkinter import ThemeManager
+
+    for cls in ("CTkButton", "CTkOptionMenu"):
+        loaded_fg = ThemeManager.theme[cls]["fg_color"]
+        assert loaded_fg == data[cls]["fg_color"], f"{cls} fg didn't load from the file (blue fallback?)"
+        assert not _CTK_BLUE_FALLBACK.intersection(loaded_fg), f"{cls} is on the blue fallback"
+        # The premise: neutral by default, never the brand red.
+        assert gtu.NLP_SUITE_ACCENT not in loaded_fg, f"{cls} default fill must be neutral, not brand red"
+
+
+# ── the accent is red, opt-in, and distinct from the muted 'nothing available' grey ──
+def test_accent_constants_are_the_brand_red_and_distinct_from_muted():
+    # The RUN button and the "available" TIPS/videos/reminders dropdowns opt into this red.
+    assert gtu.NLP_SUITE_ACCENT in gtu._ACCENT_FG
+    # accent (available, red) and muted (nothing available, grey) must be visibly different cues.
+    assert gtu._ACCENT_FG != gtu._MUTED_FG
+    assert gtu.NLP_SUITE_ACCENT != gtu._MUTED_FG


### PR DESCRIPTION
Retargeted from fork PR coralynnkc/NLP-Suite#3 now that its stacked base (`ctk/phase1-core`, slice 1 + 2a) has merged into `roberto` (#1645). Rebased onto current `roberto`.

Slice **2b** retires the absolute-pixel `.place()` layout in favor of `grid()` — the modernization the whole migration is for — and applies the first round of grid-reflow polish to the front-door GUI (`NLP_menu_main`).

### What's here
- `placeWidget` lays widgets on **grid** instead of `.place(x, y=90+40*row)`. **Signature unchanged** — no GUI script edits. Legacy row counter → grid row; x-coordinate → semantic column via a coarse left-to-right band lookup (preserves horizontal *order*, drops exact pixel spacing — that's the reflow).
- Tooltips now bind `GUI_theme_util.ToolTip` (widget-relative) instead of the coordinate-based `hover_over_widget`.
- `GUI_top`: `intro.pack()` → `intro.grid()` in the reserved header row, wrapped + left-anchored; logo stays `.place`d.

### `NLP_menu_main` grid-reflow polish (this PR)
The gridded reflow exposed several layout artifacts on the menu; all fixed here:
- **SETUP rows** — each disabled status checkbox is grouped with its wide (95-char) SETUP button in one frame, so they render as an adjacent pair. Under the coarse-band grid the checkbox was otherwise stranded ~700px from its button (its column stretched by the full-width buttons), and the two full-width button columns together overflowed the window.
- **Blank open-config buttons** — the three "open the config `.csv`" buttons were `tk.Button(text='')` rendering as empty white boxes; they now show a 📂 folder glyph.
- **Outdated font** — the SETUP buttons, the red info buttons, and the notebook tabs dropped the legacy `Courier` monospace for the native system UI font (`TkDefaultFont` family: `.AppleSystemUIFont` on macOS, Segoe UI on Windows).
- **Notebook** — gridded (was `.place`d, floating over the chrome); trimmed the dead vertical space (height 210 → 150); the themed combobox's char-based width rendered only ~150px, so the dropdowns now take an explicit pixel width and fill the row up to the ? HELP buttons instead of floating in a wide empty gray band.
- **Top nav buttons** (`GUI_util`, welcome + menu only) — About / Release history / NLP Suite team / How to cite were gridded into separate columns and shoved off the right edge by the wide setup/info buttons (`team` clipped, `cite` gone). They're now a compact **2×2 block** `place()`d in the top-right corner, out of the grid so they can't overflow it and clear of the welcome text.

### Verification
- Launched the real menu and screenshotted after each change (setup rows, nav block, folder icons, notebook — all clean).
- `tests/gui_smoke.py`: **44 GUIs OK, 0 missing golden labels**, no construction regressions from the shared `GUI_util` change (the 5 crashes are pre-existing missing-module env gaps: `spellchecker`, `pdfminer`).

---

### ✅ Status: done
This PR delivers the grid engine plus the `NLP_menu_main` reflow polish. It is no longer WIP.

### Follow-ups (out of scope for this PR)
The remaining grid-reflow items are tracked as later migration work, not blockers for this PR:
- Window geometry is still tuned to the old absolute layout (~35% empty on the right on some GUIs) — revisit `set_window` sizing.
- Multi-column GUIs (`SVO_main`, `GIS_main`) and the raw-`.place()` GUIs (`data_visualization_main`, 140 sites) are unvalidated against the column bucketing — Phase 4.
- Remove the now-dead `hover_over_widget` machinery — Phase 5 cleanup.
- Full per-GUI visual QA on macOS **and** Windows, light **and** dark.
