### PR TITLE
Pin spacy<3.8 to keep Python 3.8 installs working

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -12,7 +12,7 @@
 #used in NLP_setup_update_util for the automatic update to the latest release available on GitHub using git
 pygit2
 #
-spacy
+spacy<3.8  # 3.8+ pulls blis>=1.0, which requires numpy>=2.0 and drops Python 3.8 support
 stanza==1.5.1
 #
 pandas==1.5.2

--- a/src/requirements_mac.txt
+++ b/src/requirements_mac.txt
@@ -12,7 +12,7 @@
 #used in NLP_setup_update_util for the automatic update to the latest release available on GitHub using git
 pygit2
 #
-spacy
+spacy<3.8  # 3.8+ pulls blis>=1.0, which requires numpy>=2.0 and drops Python 3.8 support
 stanza==1.5.1
 #
 pandas==1.5.2


### PR DESCRIPTION
## Summary
- `src/requirements.txt` and `src/requirements_mac.txt` list `spacy` unpinned, which currently resolves to spacy 3.8.x
- spacy 3.8+ depends on `blis>=1.0`, whose build requirements need `numpy>=2.0` — numpy dropped Python 3.8 support entirely, so this fails outright on the project's pinned Python 3.8 env (the one `setup_Mac/STEP2-install_NLP-Suite.command` creates via `conda create -n NLP python=3.8`)
- Pinning `spacy<3.8` resolves to 3.7.5, which pulls `blis 0.7.11` / `numpy 1.24.3` — both Python 3.8-compatible

## Test plan
- [x] Verified via `pip install spacy<3.8 sacremoses contextualSpellCheck sentencepiece tensorflow` in a fresh `python=3.8` conda env — installs cleanly (spacy 3.7.5, contextualSpellCheck 0.4.4, tensorflow 2.13.0, editdistance 0.6.2, etc.)