### PR TITLE
Fix bert-extractive-summarizer install (bogus 'summarizer' dep, transformers pin)

### DIFF
--- a/src/IO_libraries_util.py
+++ b/src/IO_libraries_util.py
@@ -116,6 +116,8 @@ def install_all_Python_packages(window, calling_script, modules_to_try):
                 module = 'python-docx'  # python-docx would always break the code; must pass docx
             if 'vlc' in module:
                 module = 'python-vlc'
+            if module == 'summarizer':
+                module = 'bert-extractive-summarizer'  # PyPI's 'summarizer' is an unrelated, abandoned package
             missingModules.append(module)
             if 'spellchecker' in missingModules:
                 # rename the module to the software_name to be installed

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -95,13 +95,12 @@ twython
 nrclex
 #
 # BERT
-transformers
+transformers<4.52  # bert-extractive-summarizer imports TransfoXLModel, removed from transformers in 4.52
 sentence_transformers
 contextualSpellCheck
 tensorflow
 protobuf==3.20
 sentencepiece
-summarizer
 bert-extractive-summarizer
 bertopic
 

--- a/src/requirements_mac.txt
+++ b/src/requirements_mac.txt
@@ -95,14 +95,13 @@ twython
 nrclex
 #
 # BERT
-transformers
+transformers<4.52  # bert-extractive-summarizer imports TransfoXLModel, removed from transformers in 4.52
 sentence_transformers
 contextualSpellCheck
 tensorflow-macos
 tensorflow-metal
 protobuf==3.20
 sentencepiece
-summarizer
 bert-extractive-summarizer
 bertopic
 #


### PR DESCRIPTION
## bug found when click-testing `GIS_main.py`:

## Summary
- Drop the bogus `summarizer` line from `src/requirements.txt` / `src/requirements_mac.txt`. PyPI's `summarizer` package is an unrelated, abandoned package — it is **not** what `BERT_util.py`'s `from summarizer import Summarizer` needs. That import is provided by `bert-extractive-summarizer`, which happens to install itself under the `summarizer` module name.
- Add the same mapping to `IO_libraries_util.install_all_Python_packages`, so the auto-installer maps a failed `import summarizer` to installing `bert-extractive-summarizer` instead of the wrong `summarizer` package.
- Pin `transformers<4.52` in both requirements files. `bert-extractive-summarizer` 0.10.1 imports `TransfoXLModel` from `transformers` at module load time; that class was removed from `transformers` in 4.52, so a fresh, unpinned install breaks `from summarizer import Summarizer` with `ImportError: cannot import name 'TransfoXLModel' from 'transformers'`.

## Test plan
- [x] Reproduced the failure on a fresh env with unpinned `transformers` (5.14.1): `from summarizer import Summarizer` raised `ImportError: cannot import name 'TransfoXLModel'`.
- [x] `pip install "transformers<4.52"` (resolved to 4.51.3) fixed the import locally.
- [x] CI / maintainer to confirm `bert-extractive-summarizer` install path is clean on a fresh env with these requirements files.